### PR TITLE
Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+## 0.4.3 *(2025-12-30)*
+- Enable return-value-checker.
+- Enable `explicitApi` by default and remove it from base extension.
+- Update java-toolchain version to 25.
+- Dependency updates.
+
 ## 0.4.2
 - Rename `useSkies()` to `useSkie()`
 - Fix typo in release key alias property (`rReleaseKeyAlias` → `releaseKeyAlias`)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 java-target = "21"
-java-toolchain = "21"
+java-toolchain = "25"
 ktlint = "1.4.0"
 
 agp = "8.13.1"

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BasePlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BasePlugin.kt
@@ -69,6 +69,7 @@ public abstract class BasePlugin : Plugin<Project> {
                     "-Xcontext-parameters",
                     "-Xcontext-sensitive-resolution",
                     "-Xannotation-target-all",
+                    "-Xreturn-value-checker=full",
                     // opt in to experimental apis
                     "-opt-in=kotlin.time.ExperimentalTime",
                     "-opt-in=kotlin.uuid.ExperimentalUuidApi",

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BasePlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BasePlugin.kt
@@ -46,6 +46,8 @@ public abstract class BasePlugin : Plugin<Project> {
 
     private fun Project.configureKotlin() {
         kotlin {
+            explicitApi()
+
             jvmToolchain { toolchain ->
                 toolchain.languageVersion.set(javaToolchainVersion)
                 toolchain.vendor.set(JvmVendorSpec.AZUL)

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
@@ -30,12 +30,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFrameworkConfig
 
 public abstract class BaseExtension(private val project: Project) : ExtensionAware {
-    public fun explicitApi() {
-        project.kotlin {
-            explicitApi()
-        }
-    }
-
     public fun optIn(vararg classes: String) {
         project.kotlin {
             compilerOptions {

--- a/renovate.json
+++ b/renovate.json
@@ -1,34 +1,35 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    ":disableRateLimiting",
-    ":semanticCommitsDisabled"
-  ],
-  "platformCommit": true,
-  "rebaseWhen": "conflicted",
-  "gitAuthor": "Renovate Bot <renovate-bot@github.com>",
-  "ignorePaths": [
-    "**/.ruby-version"
-  ],
-  "packageRules": [
-    {
-      "matchDatasources": [
-        "maven"
-      ],
-      "registryUrls": [
-        "https://repo.maven.apache.org/maven2",
-        "https://dl.google.com/android/maven2",
-        "https://plugins.gradle.org/m2"
-      ]
-    },
-    {
-      "groupName": "Kotlin, KSP & Skie",
-      "matchPackagePatterns": [
-        "org.jetbrains.kotlin",
-        "com.google.devtools.ksp",
-        "co.touchlab.skie"
-      ]
-    }
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:base",
+        ":disableRateLimiting",
+        ":semanticCommitsDisabled"
+    ],
+    "labels": ["renovate"],
+    "platformCommit": true,
+    "rebaseWhen": "conflicted",
+    "gitAuthor": "Renovate Bot <renovate-bot@github.com>",
+    "ignorePaths": [
+        "**/.ruby-version"
+    ],
+    "packageRules": [
+        {
+            "matchDatasources": [
+                "maven"
+            ],
+            "registryUrls": [
+                "https://repo.maven.apache.org/maven2",
+                "https://dl.google.com/android/maven2",
+                "https://plugins.gradle.org/m2"
+            ]
+        },
+        {
+            "groupName": "Kotlin, KSP & Skie",
+            "matchPackagePatterns": [
+                "org.jetbrains.kotlin",
+                "com.google.devtools.ksp",
+                "co.touchlab.skie"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
## Changes
- Enable return-value-checker.
- Enable `explicitApi` by default and remove it from base extension.
- Update java-toolchain version to 25.