### PR TITLE
Release automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+## 0.6.0 *(2026-03-24)*
+- Add release automation tasks (`bumpVersion`, `release`).
+- Dependency updates.
+
 ## 0.5.1 *(2026-02-26)*
 - Enable new compiler features: explicit backing fields, reified types in catch clauses, and `@all:` annotation target.
 - Fix dependency analysis plugin configuration for KMP projects.

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlin.native.binary.smallBinary=true
 
 # Publishing Configuration
 GROUP=io.github.thomaskioko.gradle.plugins
-VERSION_NAME=0.5.1
+VERSION_NAME=0.6.0
 INCEPTION_YEAR=2025
 
 POM_REPO_NAME=app-gradle-plugins

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,9 @@
 [versions]
+clikt = "5.1.0"
+mordant = "3.0.2"
 java-target = "21"
 java-toolchain = "25"
+junit = "4.13.2"
 ktlint = "1.4.0"
 
 agp = "9.1.0"
@@ -17,6 +20,7 @@ skie = "0.10.10"
 spotless = "8.3.0"
 
 [libraries]
+mordant-core = { module = "com.github.ajalt.mordant:mordant-core", version.ref = "mordant" }
 baselineprofile-gradlePlugin = { group = "androidx.benchmark", name = "benchmark-baseline-profile-gradle-plugin", version.ref = "baselineprofile" }
 spotless-gradle-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
@@ -32,6 +36,7 @@ dependency-analysis-gradle-plugin = { module = "com.autonomousapps:dependency-an
 gradle-doctor-gradle-plugin = { group = "com.osacky.doctor", name = "doctor-plugin", version.ref = "gradle-doctor" }
 skie-gradle-plugin = { module = "co.touchlab.skie:gradle-plugin", version.ref = "skie" }
 ksp-gradle = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin",  version.ref = "ksp" }
+junit = { module = "junit:junit", version.ref = "junit" }
 
 [plugins]
 app-root = { id = "io.github.thomaskioko.gradle.plugins.root",  version.ref = "app-gradle-plugins" }

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -44,6 +44,10 @@ dependencies {
     compileOnly(libs.baselineprofile.gradlePlugin)
     compileOnly(libs.skie.gradle.plugin)
     compileOnly(libs.spotless.gradle.plugin)
+    implementation(libs.mordant.core)
+
+    testImplementation(libs.junit)
+    testImplementation(gradleTestKit())
 }
 
 gradlePlugin {

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/AppPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/AppPlugin.kt
@@ -1,13 +1,17 @@
 package io.github.thomaskioko.gradle.plugins
 
 import io.github.thomaskioko.gradle.plugins.extensions.AppExtension
+import io.github.thomaskioko.gradle.plugins.utils.Versioning
+import io.github.thomaskioko.gradle.plugins.utils.Versioning.compute
 import io.github.thomaskioko.gradle.plugins.utils.androidApp
 import io.github.thomaskioko.gradle.plugins.utils.androidComponents
 import io.github.thomaskioko.gradle.plugins.utils.baseExtension
 import io.github.thomaskioko.gradle.plugins.utils.disableAndroidApplicationTasks
-import io.github.thomaskioko.gradle.plugins.utils.getVersion
 import io.github.thomaskioko.gradle.plugins.utils.isDebugOnlyBuild
+import io.github.thomaskioko.gradle.plugins.utils.parseKeyValueFile
 import io.github.thomaskioko.gradle.plugins.utils.stringProperty
+import io.github.thomaskioko.gradle.tasks.release.BumpVersionTask
+import io.github.thomaskioko.gradle.tasks.release.ReleaseTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -18,14 +22,50 @@ public abstract class AppPlugin : Plugin<Project> {
 
         target.baseExtension.extensions.create("app", AppExtension::class.java)
 
+        val versionFile = target.rootProject.file("version.txt")
+        target.tasks.register("bumpVersion", BumpVersionTask::class.java) {
+            it.versionFile.set(versionFile)
+            it.bumpType.convention(
+                target.stringProperty("type").orElse("minor"),
+            )
+        }
+
+        val changelogFile = target.rootProject.file("CHANGELOG.md")
+        val cliffConfig = target.rootProject.file("cliff.toml")
+        target.tasks.register("release", ReleaseTask::class.java) {
+            it.versionFile.set(versionFile)
+            it.changelogFile.set(changelogFile)
+            it.cliffConfigFile.set(cliffConfig)
+            it.projectDir.set(target.rootProject.layout.projectDirectory)
+            it.bumpType.convention(
+                target.stringProperty("type").orElse("minor"),
+            )
+            it.beta.convention(
+                target.stringProperty("beta").map { true }.orElse(false),
+            )
+            it.interactive.convention(
+                target.stringProperty("i").map { true }.orElse(false),
+            )
+            it.dryRun.convention(
+                target.stringProperty("dryRun").map { true }.orElse(false),
+            )
+        }
+
         target.androidApp {
             buildFeatures {
                 buildConfig = true
             }
 
+            val versionProps = target.parseKeyValueFile("version.txt")
+            val resolvedVersionName = requireNotNull(versionProps["VERSION_NUMBER"]) {
+                "VERSION_NUMBER not found in version.txt. Ensure version.txt exists at the project root."
+            }
+
+            val versionSuffix = target.stringProperty("app.versionSuffix").orElse("-beta").get()
+
             defaultConfig {
-                versionCode = target.getVersion("app-version-code").toInt()
-                versionName = target.getVersion("app-version-name")
+                versionCode = compute(resolvedVersionName)
+                versionName = resolvedVersionName + versionSuffix
                 manifestPlaceholders["appAuthRedirectScheme"] = "app"
             }
 

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/VersionCatalog.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/VersionCatalog.kt
@@ -48,6 +48,22 @@ internal fun Project.getBundleDependencies(name: String): Provider<ExternalModul
  */
 internal fun Project.getDependencyOrNull(name: String): Provider<MinimalExternalModuleDependency>? = libs.findLibrary(name).orElseGet { null }
 
+/**
+ * Parses a key-value file (e.g., `version.txt`) from the root project directory.
+ * Lines must be in `KEY = VALUE` format. Lines starting with `//` are treated as comments.
+ * Returns an empty map if the file does not exist.
+ */
+internal fun Project.parseKeyValueFile(fileName: String): Map<String, String> {
+    val file = rootProject.file(fileName)
+    if (!file.exists()) return emptyMap()
+    return file.readLines()
+        .filter { it.contains("=") && !it.trimStart().startsWith("//") }
+        .associate { line ->
+            val (key, value) = line.split("=", limit = 2).map { it.trim() }
+            key to value
+        }
+}
+
 internal val Project.javaTarget: String
     get() = getVersion("java-target")
 

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/Versioning.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/Versioning.kt
@@ -1,0 +1,47 @@
+package io.github.thomaskioko.gradle.plugins.utils
+
+public object Versioning {
+
+  public val VERSION_REGEX: Regex = Regex("""VERSION_NUMBER\s*=\s*(\S+)""")
+  public val BUILD_REGEX: Regex = Regex("""BUILD_NUMBER\s*=\s*(\S+)""")
+
+  public fun compute(versionName: String, betaNumber: Int = 0): Int {
+    val (major, minor, patch) = parseSemver(versionName)
+    require(major in 0..209) { "Major version must be 0-209, got: $major" }
+    require(minor in 0..99) { "Minor version must be 0-99, got: $minor" }
+    require(patch in 0..99) { "Patch version must be 0-99, got: $patch" }
+    require(betaNumber in 0..999) { "Beta number must be 0-999, got: $betaNumber" }
+    val result = (major * 10_000_000) + (minor * 100_000) + (patch * 1_000) + betaNumber
+    require(result in 0..Int.MAX_VALUE) { "Version code overflow: $versionName produces $result" }
+    return result
+  }
+
+  public fun bump(versionName: String, bumpType: String): BumpResult {
+    val (major, minor, patch) = parseSemver(versionName)
+    val (newMajor, newMinor, newPatch) = when (bumpType) {
+      "major" -> Triple(major + 1, 0, 0)
+      "minor" -> Triple(major, minor + 1, 0)
+      "patch" -> Triple(major, minor, patch + 1)
+      else -> throw IllegalArgumentException("bumpType must be major, minor, or patch, got: $bumpType")
+    }
+    val newVersion = "$newMajor.$newMinor.$newPatch"
+    val buildNumber = compute(newVersion)
+    return BumpResult(newVersion, buildNumber)
+  }
+
+  private fun parseSemver(versionName: String): Triple<Int, Int, Int> {
+    val parts = versionName.split(".")
+    require(parts.size == 3) { "Version must be in major.minor.patch format, got: $versionName" }
+    val (major, minor, patch) = parts.map {
+      it.toIntOrNull() ?: throw IllegalArgumentException(
+        "Version components must be integers, got: '$it' in '$versionName'",
+      )
+    }
+    return Triple(major, minor, patch)
+  }
+
+  public data class BumpResult(
+    val versionName: String,
+    val buildNumber: Int,
+  )
+}

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/BumpVersionTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/BumpVersionTask.kt
@@ -1,0 +1,49 @@
+package io.github.thomaskioko.gradle.tasks.release
+
+import io.github.thomaskioko.gradle.plugins.utils.Versioning
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+@UntrackedTask(because = "Modifies version.txt in place")
+public abstract class BumpVersionTask : DefaultTask() {
+
+  init {
+    description = "Bumps VERSION_NUMBER (major/minor/patch) and recomputes BUILD_NUMBER in version.txt"
+    group = "versioning"
+  }
+
+  @get:Internal
+  public abstract val versionFile: RegularFileProperty
+
+  @get:Input
+  public abstract val bumpType: Property<String>
+
+  @TaskAction
+  public fun bump() {
+    val file = versionFile.get().asFile
+    require(file.exists()) { "version.txt not found at ${file.path}" }
+
+    val content = file.readText()
+    val versionMatch = Versioning.VERSION_REGEX.find(content)
+      ?: error("VERSION_NUMBER not found in ${file.path}")
+    val currentVersion = versionMatch.groupValues[1]
+
+    val result = Versioning.bump(currentVersion, bumpType.get())
+
+    require(Versioning.BUILD_REGEX.containsMatchIn(content)) {
+      "BUILD_NUMBER not found in ${file.path}"
+    }
+
+    val updated = content
+      .replace(Versioning.VERSION_REGEX, "VERSION_NUMBER = ${result.versionName}")
+      .replace(Versioning.BUILD_REGEX, "BUILD_NUMBER = ${result.buildNumber}")
+    file.writeText(updated)
+
+    logger.lifecycle("$currentVersion -> ${result.versionName} (BUILD_NUMBER = ${result.buildNumber})")
+  }
+}

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/ReleaseTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/ReleaseTask.kt
@@ -1,0 +1,416 @@
+package io.github.thomaskioko.gradle.tasks.release
+
+import com.github.ajalt.mordant.terminal.ConversionResult
+import com.github.ajalt.mordant.terminal.Terminal
+import com.github.ajalt.mordant.terminal.YesNoPrompt
+import com.github.ajalt.mordant.terminal.prompt
+import io.github.thomaskioko.gradle.plugins.utils.Versioning
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
+import java.io.File
+import javax.inject.Inject
+
+@UntrackedTask(because = "Modifies version.txt, CHANGELOG.md and creates git commit + tag")
+public abstract class ReleaseTask @Inject constructor(
+  private val execOperations: ExecOperations,
+) : DefaultTask() {
+
+  init {
+    description = "Bumps version, updates changelog, commits, and tags. Pass -Pi for interactive mode."
+    group = "versioning"
+  }
+
+  @get:Internal
+  public abstract val versionFile: RegularFileProperty
+
+  @get:Internal
+  public abstract val changelogFile: RegularFileProperty
+
+  @get:Internal
+  public abstract val cliffConfigFile: RegularFileProperty
+
+  @get:Internal
+  public abstract val projectDir: DirectoryProperty
+
+  @get:Input
+  public abstract val bumpType: Property<String>
+
+  @get:Input
+  public abstract val beta: Property<Boolean>
+
+  @get:Input
+  public abstract val interactive: Property<Boolean>
+
+  @get:Input
+  public abstract val dryRun: Property<Boolean>
+
+  @TaskAction
+  public fun release() {
+    requireGitCliff()
+
+    if (interactive.get()) {
+      runInteractive()
+    } else {
+      val validTypes = setOf("major", "minor", "patch")
+      require(bumpType.get() in validTypes) {
+        "Invalid bump type '${bumpType.get()}'. Must be one of: ${validTypes.joinToString()}"
+      }
+      runSilent()
+    }
+  }
+
+  private fun runSilent() {
+    val file = versionFile.get().asFile
+    require(file.exists()) { "version.txt not found at ${file.path}" }
+
+    val content = file.readText()
+    val currentVersion = parseVersion(content, file.path)
+    val result = Versioning.bump(currentVersion, bumpType.get())
+    val isBeta = beta.get()
+    val branch = currentBranch()
+    val tag = buildTag(result.versionName, isBeta, branch)
+
+    runChecks(file.toRelativeString(projectDir.get().asFile), tag, isBeta, branch) { label, block ->
+      block()
+    }
+
+    val recentTags = recentReleaseTags()
+    if (recentTags.isNotEmpty()) {
+      logger.lifecycle("Recent releases: ${recentTags.joinToString(", ")}")
+    }
+
+    if (dryRun.get()) {
+      printDryRun(currentVersion, result, tag)
+      return
+    }
+
+    writeVersionFile(file, content, result)
+
+    val changelog = changelogFile.get().asFile
+    generateChangelog(changelog, tag)
+
+    git("add", file.absolutePath)
+    git("add", changelog.absolutePath)
+    git("commit", "-m", "release: $tag")
+    git("tag", "-a", tag, "-m", "Release $tag")
+
+    logger.lifecycle("$currentVersion -> ${result.versionName} (BUILD_NUMBER = ${result.buildNumber})")
+    logger.lifecycle("Created commit and tag: $tag")
+    logger.lifecycle("Push with: git push origin $branch --tags")
+  }
+
+  private fun runInteractive() {
+    val terminal = Terminal()
+    val file = versionFile.get().asFile
+    require(file.exists()) { "version.txt not found at ${file.path}" }
+
+    val content = file.readText()
+    val currentVersion = parseVersion(content, file.path)
+    val isBeta = beta.get()
+    val branch = currentBranch()
+
+    terminal.println("Current version: $currentVersion")
+
+    val recentTags = recentReleaseTags()
+    if (recentTags.isNotEmpty()) {
+      terminal.println("Recent releases: ${recentTags.joinToString(", ")}")
+    }
+
+    terminal.println("")
+    runChecks(file.toRelativeString(projectDir.get().asFile), tag = null, isBeta, branch) { label, block ->
+      terminal.print("  $label...")
+      block()
+      terminal.println(" ✔")
+    }
+
+    val bumpType = promptBumpType(terminal)
+    val result = Versioning.bump(currentVersion, bumpType)
+    val tag = buildTag(result.versionName, isBeta, branch)
+
+    val existingTag = gitOutput("tag", "--list", tag)
+    require(existingTag.isBlank()) { "Tag '$tag' already exists." }
+
+    terminal.println("")
+    terminal.println("  $currentVersion → ${result.versionName}  (BUILD_NUMBER = ${result.buildNumber})")
+    terminal.println("")
+
+    if (dryRun.get()) {
+      val preview = previewChangelog(tag)
+      if (preview.isNotBlank()) {
+        terminal.println("Changelog preview:")
+        terminal.println(preview)
+        terminal.println("")
+      }
+      terminal.println("Dry run complete. No files modified, no commits or tags created.")
+      return
+    }
+
+    val preview = previewChangelog(tag)
+    if (preview.isNotBlank()) {
+      terminal.println("Changelog preview:")
+      terminal.println(preview)
+      terminal.println("")
+    } else {
+      terminal.println("No commits since last tag.")
+    }
+
+    val confirmed = YesNoPrompt(
+      prompt = "Commit version.txt, update CHANGELOG.md, and tag $tag?",
+      terminal = terminal,
+    ).ask() == true
+
+    if (!confirmed) {
+      terminal.println("Aborted.")
+      return
+    }
+
+    writeVersionFile(file, content, result)
+
+    val changelog = changelogFile.get().asFile
+    generateChangelog(changelog, tag)
+    terminal.println("Updated ${changelog.name}")
+
+    git("add", file.absolutePath)
+    git("add", changelog.absolutePath)
+    git("commit", "-m", "release: $tag")
+    git("tag", "-a", tag, "-m", "Release $tag")
+
+    terminal.println("Created commit and tag: $tag")
+
+    val pushConfirmed = YesNoPrompt(
+      prompt = "Push commit and tag to origin?",
+      terminal = terminal,
+    ).ask() == true
+
+    if (pushConfirmed) {
+      git("push", "origin", branch, "--tags")
+      terminal.println("Pushed to origin/$branch with tags.")
+    } else {
+      terminal.println("Skipped push. Run manually: git push origin $branch --tags")
+    }
+  }
+
+  private fun printDryRun(currentVersion: String, result: Versioning.BumpResult, tag: String) {
+    logger.lifecycle("$currentVersion → ${result.versionName} (BUILD_NUMBER = ${result.buildNumber})")
+    logger.lifecycle("Tag: $tag")
+
+    val preview = previewChangelog(tag)
+    if (preview.isNotBlank()) {
+      logger.lifecycle("Changelog preview:")
+      logger.lifecycle(preview)
+    }
+
+    logger.lifecycle("Dry run complete. No files modified, no commits or tags created.")
+  }
+
+  private fun parseVersion(content: String, path: String): String {
+    val match = Versioning.VERSION_REGEX.find(content)
+      ?: error("VERSION_NUMBER not found in $path")
+    return match.groupValues[1]
+  }
+
+  private fun writeVersionFile(file: File, content: String, result: Versioning.BumpResult) {
+    require(Versioning.BUILD_REGEX.containsMatchIn(content)) {
+      "BUILD_NUMBER not found in ${file.path}"
+    }
+    val updated = content
+      .replace(Versioning.VERSION_REGEX, "VERSION_NUMBER = ${result.versionName}")
+      .replace(Versioning.BUILD_REGEX, "BUILD_NUMBER = ${result.buildNumber}")
+    file.writeText(updated)
+  }
+
+  private fun runChecks(
+    versionFilePath: String,
+    tag: String?,
+    isBeta: Boolean,
+    branch: String,
+    reporter: (label: String, block: () -> Unit) -> Unit,
+  ) {
+    if (isBeta) {
+      reporter("On branch '$branch'") {}
+    } else {
+      reporter("On main branch") {
+        require(branch == "main") { "Must be on 'main' branch to release, currently on '$branch'." }
+      }
+    }
+
+    reporter("Clean working tree") {
+      val dirty = gitOutput("status", "--porcelain")
+        .lines()
+        .filter { it.isNotBlank() }
+        .filter { line -> parsePorcelainPaths(line).none { it == versionFilePath } }
+      require(dirty.isEmpty()) {
+        "Working tree has uncommitted changes:\n${dirty.joinToString("\n")}\nCommit or stash them before releasing."
+      }
+    }
+
+    reporter("Fetching remote") {
+      git("fetch", "--tags")
+      val fetchResult = execOperations.exec {
+        it.commandLine("git", "fetch", "origin", branch)
+        it.isIgnoreExitValue = true
+      }
+      if (fetchResult.exitValue != 0) {
+        logger.lifecycle("Remote branch 'origin/$branch' not found — pushing branch to origin.")
+        git("push", "-u", "origin", branch)
+      }
+    }
+
+    reporter("Branch up-to-date") {
+      val behind = gitOutput("rev-list", "--count", "HEAD..origin/$branch")
+      require(behind == "0") { "Local branch is $behind commit(s) behind origin/$branch. Pull before releasing." }
+    }
+
+    if (tag != null) {
+      val existing = gitOutput("tag", "--list", tag)
+      require(existing.isBlank()) { "Tag '$tag' already exists. Choose a different version or delete the existing tag." }
+    }
+  }
+
+  private fun recentReleaseTags(): List<String> =
+    gitOutput("tag", "--list", "v*", "--sort=-version:refname")
+      .lines()
+      .filter { it.isNotBlank() }
+      .take(5)
+
+  private fun promptBumpType(terminal: Terminal): String {
+    val validTypes = listOf("major", "minor", "patch")
+    return terminal.prompt(
+      prompt = "Bump type (major/minor/patch)",
+      default = "minor",
+      convert = { input: String ->
+        val normalized = input.trim().lowercase()
+        if (normalized in validTypes) {
+          ConversionResult.Valid(normalized)
+        } else {
+          ConversionResult.Invalid("Must be one of: ${validTypes.joinToString()}")
+        }
+      },
+    ) ?: "minor"
+  }
+
+  private fun requireGitCliff() {
+    val output = ByteArrayOutputStream()
+    val errOutput = ByteArrayOutputStream()
+    try {
+      val result = execOperations.exec {
+        it.commandLine("git-cliff", "--version")
+        it.standardOutput = output
+        it.errorOutput = errOutput
+        it.isIgnoreExitValue = true
+      }
+      require(result.exitValue == 0) {
+        "git-cliff is required but returned exit code ${result.exitValue}. " +
+          "Install it: brew install git-cliff\n" +
+          "See: https://git-cliff.org/docs/installation"
+      }
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+      if (e is IllegalArgumentException) throw e
+      throw IllegalStateException(
+        "git-cliff is required but not found on PATH. " +
+          "Install it: brew install git-cliff\n" +
+          "See: https://git-cliff.org/docs/installation",
+        e,
+      )
+    }
+  }
+
+  private fun cliffConfigArgs(): List<String> {
+    val configFile = cliffConfigFile.orNull?.asFile
+    return if (configFile != null && configFile.exists()) {
+      listOf("--config", configFile.absolutePath)
+    } else {
+      emptyList()
+    }
+  }
+
+  private fun previewChangelog(tag: String): String {
+    val output = ByteArrayOutputStream()
+    val errOutput = ByteArrayOutputStream()
+    val result = execOperations.exec {
+      it.commandLine(
+        buildList {
+          add("git-cliff")
+          addAll(cliffConfigArgs())
+          add("--unreleased")
+          add("--tag")
+          add(tag)
+          add("--strip")
+          add("header")
+        },
+      )
+      it.standardOutput = output
+      it.errorOutput = errOutput
+      it.isIgnoreExitValue = true
+    }
+    if (result.exitValue != 0) {
+      val stderr = errOutput.toString().trim()
+      logger.warn("git-cliff preview failed (exit ${result.exitValue}): $stderr")
+      return ""
+    }
+    return output.toString().trim()
+  }
+
+  private fun generateChangelog(file: File, tag: String) {
+    val errOutput = ByteArrayOutputStream()
+    val result = execOperations.exec {
+      it.commandLine(
+        buildList {
+          add("git-cliff")
+          addAll(cliffConfigArgs())
+          add("--tag")
+          add(tag)
+          add("-o")
+          add(file.absolutePath)
+        },
+      )
+      it.errorOutput = errOutput
+      it.isIgnoreExitValue = true
+    }
+    require(result.exitValue == 0) {
+      "git-cliff failed (exit ${result.exitValue}): ${errOutput.toString().trim()}"
+    }
+  }
+
+  private fun currentBranch(): String =
+    gitOutput("rev-parse", "--abbrev-ref", "HEAD")
+
+  private fun gitOutput(vararg args: String): String {
+    val output = ByteArrayOutputStream()
+    execOperations.exec {
+      it.commandLine("git", *args)
+      it.standardOutput = output
+    }
+    return output.toString().trim()
+  }
+
+  private fun git(vararg args: String) {
+    execOperations.exec {
+      it.commandLine("git", *args)
+    }
+  }
+
+  internal companion object {
+    internal fun buildTag(versionName: String, isBeta: Boolean, branch: String): String =
+      if (isBeta) "v$versionName-beta.${sanitizeBranchForTag(branch)}" else "v$versionName"
+
+    internal fun sanitizeBranchForTag(branch: String): String =
+      branch.replace(Regex("[^a-zA-Z0-9._-]"), "-")
+        .replace(Regex("-{2,}"), "-")
+        .trim('-')
+
+    internal fun parsePorcelainPaths(line: String): List<String> {
+      if (line.length < 3) return emptyList()
+      val path = line.substring(3) // skip "XY "
+      return if (" -> " in path) path.split(" -> ") else listOf(path)
+    }
+  }
+}

--- a/plugins/src/test/kotlin/io/github/thomaskioko/gradle/plugins/utils/VersioningTest.kt
+++ b/plugins/src/test/kotlin/io/github/thomaskioko/gradle/plugins/utils/VersioningTest.kt
@@ -1,0 +1,145 @@
+package io.github.thomaskioko.gradle.plugins.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class VersioningTest {
+
+  @Test
+  fun `should return 100000 given version 0_1_0`() {
+    assertEquals(100_000, Versioning.compute("0.1.0"))
+  }
+
+  @Test
+  fun `should return 10203000 given version 1_2_3`() {
+    assertEquals(10_203_000, Versioning.compute("1.2.3"))
+  }
+
+  @Test
+  fun `should return 1000 given version 0_0_1`() {
+    assertEquals(1_000, Versioning.compute("0.0.1"))
+  }
+
+  @Test
+  fun `should stay under 2_1B given max version 209_99_99`() {
+    val result = Versioning.compute("209.99.99")
+    assertEquals(2_099_999_000, result)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw when version format is invalid`() {
+    Versioning.compute("1.2")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw when major version is above 209`() {
+    Versioning.compute("210.0.0")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw when minor version is above 99`() {
+    Versioning.compute("1.100.0")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw when patch version is above 99`() {
+    Versioning.compute("1.0.100")
+  }
+
+  @Test
+  fun `should increment patch when bump type is patch`() {
+    val result = Versioning.bump("0.1.0", "patch")
+    assertEquals("0.1.1", result.versionName)
+    assertEquals(101_000, result.buildNumber)
+  }
+
+  @Test
+  fun `should increment minor and reset patch when bump type is minor`() {
+    val result = Versioning.bump("0.1.0", "minor")
+    assertEquals("0.2.0", result.versionName)
+    assertEquals(200_000, result.buildNumber)
+  }
+
+  @Test
+  fun `should increment major and reset minor and patch when bump type is major`() {
+    val result = Versioning.bump("0.1.0", "major")
+    assertEquals("1.0.0", result.versionName)
+    assertEquals(10_000_000, result.buildNumber)
+  }
+
+  @Test
+  fun `should increment patch given non-zero version values`() {
+    val result = Versioning.bump("1.2.3", "patch")
+    assertEquals("1.2.4", result.versionName)
+    assertEquals(10_204_000, result.buildNumber)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw when bump type is invalid`() {
+    Versioning.bump("0.1.0", "hotfix")
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw when version contains non-numeric component`() {
+    Versioning.compute("1.2.abc")
+  }
+
+  @Test
+  fun `should include invalid component in error message`() {
+    val e = assertThrows(IllegalArgumentException::class.java) {
+      Versioning.compute("1.2.abc")
+    }
+    assert(e.message!!.contains("'abc'")) { "Expected error to mention 'abc', got: ${e.message}" }
+    assert(e.message!!.contains("1.2.abc")) { "Expected error to mention '1.2.abc', got: ${e.message}" }
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw when version contains negative number`() {
+    Versioning.compute("-1.0.0")
+  }
+
+  @Test
+  fun `should handle patch bump at high patch value`() {
+    val result = Versioning.bump("0.99.98", "patch")
+    assertEquals("0.99.99", result.versionName)
+    assertEquals(9_999_000, result.buildNumber)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw when patch bump exceeds limit`() {
+    Versioning.bump("0.99.99", "patch")
+  }
+
+  @Test
+  fun `should add beta number to version code`() {
+    assertEquals(100_003, Versioning.compute("0.1.0", betaNumber = 3))
+  }
+
+  @Test
+  fun `should return base version code when beta number is zero`() {
+    assertEquals(100_000, Versioning.compute("0.1.0", betaNumber = 0))
+  }
+
+  @Test
+  fun `should support max beta number 999`() {
+    assertEquals(100_999, Versioning.compute("0.1.0", betaNumber = 999))
+  }
+
+  @Test
+  fun `should produce beta code less than next patch`() {
+    val beta = Versioning.compute("0.1.0", betaNumber = 999)
+    val nextPatch = Versioning.compute("0.1.1")
+    assert(beta < nextPatch) { "Beta code $beta should be less than next patch code $nextPatch" }
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw when beta number exceeds 999`() {
+    Versioning.compute("0.1.0", betaNumber = 1000)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `should throw when beta number is negative`() {
+    Versioning.compute("0.1.0", betaNumber = -1)
+  }
+}

--- a/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/release/ReleaseHelperTest.kt
+++ b/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/release/ReleaseHelperTest.kt
@@ -1,0 +1,72 @@
+package io.github.thomaskioko.gradle.tasks.release
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReleaseHelperTest {
+
+  @Test
+  fun `buildTag production release`() {
+    assertEquals("v0.2.0", ReleaseTask.buildTag("0.2.0", false, "main"))
+  }
+
+  @Test
+  fun `buildTag beta with feature branch`() {
+    assertEquals("v0.2.0-beta.feature-auth", ReleaseTask.buildTag("0.2.0", true, "feature/auth"))
+  }
+
+  @Test
+  fun `buildTag beta with simple branch`() {
+    assertEquals("v1.0.0-beta.develop", ReleaseTask.buildTag("1.0.0", true, "develop"))
+  }
+
+  @Test
+  fun `sanitizeBranchForTag replaces special characters`() {
+    assertEquals("fix-bug-1-test", ReleaseTask.sanitizeBranchForTag("fix/bug~1:test"))
+  }
+
+  @Test
+  fun `sanitizeBranchForTag collapses consecutive dashes`() {
+    assertEquals("a-b", ReleaseTask.sanitizeBranchForTag("a//b"))
+  }
+
+  @Test
+  fun `sanitizeBranchForTag trims leading and trailing dashes`() {
+    assertEquals("branch", ReleaseTask.sanitizeBranchForTag("/branch/"))
+  }
+
+  @Test
+  fun `sanitizeBranchForTag preserves dots and underscores`() {
+    assertEquals("release_1.0", ReleaseTask.sanitizeBranchForTag("release_1.0"))
+  }
+
+  @Test
+  fun `sanitizeBranchForTag handles complex branch names`() {
+    assertEquals("user-feat-add..thing", ReleaseTask.sanitizeBranchForTag("user/feat^add..thing"))
+  }
+
+  @Test
+  fun `parsePorcelainPaths normal modified file`() {
+    assertEquals(listOf("src/Foo.kt"), ReleaseTask.parsePorcelainPaths("M  src/Foo.kt"))
+  }
+
+  @Test
+  fun `parsePorcelainPaths added file`() {
+    assertEquals(listOf("new-file.txt"), ReleaseTask.parsePorcelainPaths("A  new-file.txt"))
+  }
+
+  @Test
+  fun `parsePorcelainPaths rename`() {
+    assertEquals(listOf("old.kt", "new.kt"), ReleaseTask.parsePorcelainPaths("R  old.kt -> new.kt"))
+  }
+
+  @Test
+  fun `parsePorcelainPaths short line returns empty`() {
+    assertEquals(emptyList<String>(), ReleaseTask.parsePorcelainPaths("M "))
+  }
+
+  @Test
+  fun `parsePorcelainPaths untracked file`() {
+    assertEquals(listOf("untracked.txt"), ReleaseTask.parsePorcelainPaths("?? untracked.txt"))
+  }
+}


### PR DESCRIPTION
This PR adds release automation. It introduces two new Gradle tasks: `bumpVersion` for incrementing the version in `version.txt` and `release` for orchestrating the full release flow (`version bump, changelog generation
   via git-cliff`, and `Git tagging`). A Versioning utility handles SemVer parsing and version code computation. 

AppPlugin now derives versionCode and versionName dynamically from `version.txt` instead of hardcoding them.