### PR TITLE
Plugin Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Change Log
 ==========
 
+## 0.6.5 *(2026-04-09)*
+- Fix iOS test crashes for modules using moko resources.
+- Copy moko resource bundles to iOS test binaries so localization tests run on iOS.
+- Optimize `MokoResourceGeneratorTask`: remove dead incremental logic, reduce duplication, scope compile dependency to `commonMain`.
+- Add golden file tests for moko resource code generation.
+
+## 0.6.4 *(2026-04-01)*
+- Add Metro Gradle plugin and configure contribution providers.
+- Add support for Compose UI tests.
+- Dependency updates.
+
 ## 0.6.3 *(2026-03-26)*
 - Remove Tag publishing from beta builds
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ gradle-doctor = "0.12.1"
 kotlin = "2.3.20"
 kotlinPoet = "2.3.0"
 ksp="2.3.6"
-moko-resources = "0.26.0"
+metro = "0.13.2"
 publish = "0.36.0"
 skie = "0.10.11"
 spotless = "8.4.0"
@@ -34,6 +34,7 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 dependency-analysis-gradle-plugin = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependency-analysis" }
 gradle-doctor-gradle-plugin = { group = "com.osacky.doctor", name = "doctor-plugin", version.ref = "gradle-doctor" }
+metro-gradle-plugin = { module = "dev.zacsweers.metro:gradle-plugin", version.ref = "metro" }
 skie-gradle-plugin = { module = "co.touchlab.skie:gradle-plugin", version.ref = "skie" }
 ksp-gradle = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin",  version.ref = "ksp" }
 junit = { module = "junit:junit", version.ref = "junit" }

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(libs.gradle.doctor.gradle.plugin)
 
     compileOnly(libs.baselineprofile.gradlePlugin)
+    compileOnly(libs.metro.gradle.plugin)
     compileOnly(libs.skie.gradle.plugin)
     compileOnly(libs.spotless.gradle.plugin)
     implementation(libs.mordant.core)

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/KotlinMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/KotlinMultiplatformPlugin.kt
@@ -10,10 +10,12 @@ import io.github.thomaskioko.gradle.plugins.utils.getDependencyOrNull
 import io.github.thomaskioko.gradle.plugins.utils.getPackageNameProvider
 import io.github.thomaskioko.gradle.plugins.utils.kotlin
 import io.github.thomaskioko.gradle.plugins.utils.kotlinMultiplatform
+import io.github.thomaskioko.gradle.tasks.CopyMokoResourceBundlesTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
 public abstract class KotlinMultiplatformPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -66,5 +68,22 @@ public abstract class KotlinMultiplatformPlugin : Plugin<Project> {
 
         target.tasks.withType(Test::class.java).configureEach(Test::defaultTestSetup)
         target.disableMultiplatformTasks()
+
+        configureMokoResourceBundleCopy(target)
+    }
+
+    private fun configureMokoResourceBundleCopy(project: Project) {
+        project.tasks.withType(KotlinNativeLink::class.java).configureEach { linkTask ->
+            linkTask.doLast("copyMokoResourceBundles") {
+                CopyMokoResourceBundlesTask.copyBundles(
+                    klibs = linkTask.libraries.plus(linkTask.sources),
+                    outputDir = linkTask.outputFile.get().parentFile,
+                    tempDir = project.layout.buildDirectory
+                        .dir("tmp/mokoResourceBundles/${linkTask.name}")
+                        .get().asFile,
+                    logger = linkTask.logger,
+                )
+            }
+        }
     }
 }

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/ResourceGeneratorPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/ResourceGeneratorPlugin.kt
@@ -4,7 +4,7 @@ import io.github.thomaskioko.gradle.tasks.MokoResourceGeneratorTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 public class ResourceGeneratorPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -19,14 +19,23 @@ public class ResourceGeneratorPlugin : Plugin<Project> {
             }
         }
 
-        target.tasks.withType(KotlinCompile::class.java).configureEach { task ->
-            task.dependsOn(generateStringsTask)
-        }
-
         target.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
             target.extensions.configure(KotlinMultiplatformExtension::class.java) { kotlin ->
                 kotlin.sourceSets.named("commonMain") { sourceSet ->
                     sourceSet.kotlin.srcDir(generateStringsTask.map { it.commonMainOutput })
+                }
+
+                // Wire dependency only to compilations that include commonMain
+                kotlin.targets.configureEach { kmpTarget ->
+                    kmpTarget.compilations.configureEach { compilation ->
+                        if (compilation.defaultSourceSet.dependsOn.any { it.name == "commonMain" } ||
+                            compilation.defaultSourceSet.name == "commonMain"
+                        ) {
+                            compilation.compileTaskProvider.configure { task ->
+                                task.dependsOn(generateStringsTask)
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/AndroidExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/AndroidExtension.kt
@@ -60,6 +60,14 @@ public abstract class AndroidExtension(protected val project: Project) {
         }
     }
 
+    public fun useComposeTests() {
+        project.dependencies.apply {
+            add("testImplementation", project.getDependency("androidx-compose-ui-test"))
+            add("testImplementation", project.getDependency("robolectric"))
+            add("testRuntimeOnly", project.getDependency("androidx-compose-ui-test-manifest"))
+        }
+    }
+
     /**
      * Configures baseline profiles for optimizing runtime performance. Only applied on release builds.
      *

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
@@ -9,6 +9,8 @@ import co.touchlab.skie.configuration.SuspendInterop
 import co.touchlab.skie.plugin.configuration.SkieExtension
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import com.android.build.api.dsl.Lint
+import dev.zacsweers.metro.gradle.ExperimentalMetroGradleApi
+import dev.zacsweers.metro.gradle.MetroPluginExtension
 import io.github.thomaskioko.gradle.plugins.utils.addBundleImplementationDependency
 import io.github.thomaskioko.gradle.plugins.utils.addImplementationDependency
 import io.github.thomaskioko.gradle.plugins.utils.addKspDependencyForAllTargets
@@ -64,10 +66,15 @@ public abstract class BaseExtension(private val project: Project) : ExtensionAwa
         }
     }
 
+    @OptIn(ExperimentalMetroGradleApi::class)
     public fun useMetro() {
         project.plugins.apply("dev.zacsweers.metro")
 
         project.addImplementationDependency(project.getDependency("metro-runtime"))
+
+        project.extensions.configure(MetroPluginExtension::class.java) {
+            it.generateContributionProviders.set(true)
+        }
     }
 
     public fun useSerialization() {

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/CopyMokoResourceBundlesTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/CopyMokoResourceBundlesTask.kt
@@ -1,0 +1,74 @@
+package io.github.thomaskioko.gradle.tasks
+
+import org.gradle.api.file.FileCollection
+import org.gradle.api.logging.Logger
+import java.io.File
+import java.util.zip.ZipFile
+
+/**
+ * Copies .bundle resource directories from klib dependencies to an output directory.
+ * This ensures moko-resources bundles are available at runtime for iOS test binaries,
+ * not just for modules that directly apply the moko-resources plugin.
+ */
+internal object CopyMokoResourceBundlesTask {
+
+    fun copyBundles(
+        klibs: FileCollection,
+        outputDir: File,
+        tempDir: File,
+        logger: Logger,
+    ) {
+        klibs.files
+            .filter { it.exists() }
+            .flatMap { findBundles(it, tempDir) }
+            .forEach { bundle ->
+                val destination = File(outputDir, bundle.name)
+                bundle.copyRecursively(destination, overwrite = true)
+                logger.info("Copied bundle {} to {}", bundle.name, destination)
+            }
+    }
+
+    private fun findBundles(file: File, tempDir: File): List<File> {
+        if (file.isFile && file.extension == "klib") {
+            return findBundlesInPackedKlib(file, tempDir)
+        }
+        if (file.isDirectory) {
+            val resourcesDir = File(file, "default/resources")
+            if (resourcesDir.isDirectory) {
+                return resourcesDir.listFiles()
+                    ?.filter { it.isDirectory && it.extension == "bundle" }
+                    ?: emptyList()
+            }
+        }
+        return emptyList()
+    }
+
+    private fun findBundlesInPackedKlib(klibFile: File, tempDir: File): List<File> {
+        val extractDir = File(tempDir, klibFile.nameWithoutExtension)
+
+        ZipFile(klibFile).use { zf ->
+            val hasResources =
+                zf.entries().asSequence().any { it.name.startsWith("default/resources/") }
+            if (!hasResources) return emptyList()
+
+            extractDir.mkdirs()
+            zf.entries().asSequence()
+                .filter { it.name.startsWith("default/resources/") }
+                .forEach { entry ->
+                    val target = File(extractDir, entry.name.removePrefix("default/resources/"))
+                    if (entry.isDirectory) {
+                        target.mkdirs()
+                    } else {
+                        target.parentFile.mkdirs()
+                        zf.getInputStream(entry).use { input ->
+                            target.outputStream().use { output -> input.copyTo(output) }
+                        }
+                    }
+                }
+        }
+
+        return extractDir.listFiles()
+            ?.filter { it.isDirectory && it.extension == "bundle" }
+            ?: emptyList()
+    }
+}

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTask.kt
@@ -4,6 +4,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import org.gradle.api.DefaultTask
@@ -19,8 +20,6 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import org.gradle.work.Incremental
-import org.gradle.work.InputChanges
 import java.io.File
 import javax.inject.Inject
 
@@ -40,7 +39,6 @@ public abstract class MokoResourceGeneratorTask
     public val resourcePackage: Property<String> = objectFactory.property(String::class.java)
         .convention("com.thomaskioko.tvmaniac.i18n")
 
-    @get:Incremental
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     public val mokoGeneratedFile: RegularFileProperty = objectFactory.fileProperty()
@@ -56,7 +54,7 @@ public abstract class MokoResourceGeneratorTask
         .convention(layout.buildDirectory.dir("generated/resources"))
 
     @TaskAction
-    public fun generate(inputChanges: InputChanges) {
+    public fun generate() {
         val outputDir = commonMainOutput.get().asFile
         val mrFile = mokoGeneratedFile.get().asFile
         val packageName = resourcePackage.get()
@@ -66,16 +64,6 @@ public abstract class MokoResourceGeneratorTask
             return
         }
 
-        // Only regenerate if input has changed or output doesn't exist
-        if (inputChanges.isIncremental) {
-            val hasChanges = inputChanges.getFileChanges(mokoGeneratedFile).iterator().hasNext()
-            if (!hasChanges && outputDir.exists() && outputDir.listFiles()?.isNotEmpty() == true) {
-                logger.debug("Skipping generation - no changes detected")
-                return
-            }
-        }
-
-        // Clean and recreate output directory
         outputDir.deleteRecursively()
         outputDir.mkdirs()
 
@@ -95,7 +83,7 @@ public abstract class MokoResourceGeneratorTask
         ).writeTo(outputDir)
     }
 
-    private fun readKeysFromMRFile(mrFile: File): Pair<List<String>, List<String>> {
+    internal fun readKeysFromMRFile(mrFile: File): Pair<List<String>, List<String>> {
         val stringKeys = mutableListOf<String>()
         val pluralKeys = mutableListOf<String>()
         var isInStringsObject = false
@@ -142,81 +130,87 @@ public abstract class MokoResourceGeneratorTask
             ?.trim()
     }
 
-    private fun toPascalCase(name: String): String {
+    internal fun toPascalCase(name: String): String {
         return name.split('_').joinToString("") { it.replaceFirstChar { c -> c.uppercaseChar() } }
     }
 
-    private fun stringResourceKeyFileSpec(
+    internal fun stringResourceKeyFileSpec(
         packageName: String,
         stringKeys: List<String>,
         mrClass: ClassName,
-    ): FileSpec = FileSpec.builder(packageName, "StringResourceKey")
-        .addType(
-            TypeSpec.classBuilder("StringResourceKey")
-                .addModifiers(KModifier.SEALED)
-                .primaryConstructor(
-                    FunSpec.constructorBuilder()
-                        .addParameter(
-                            "resourceId",
-                            ClassName("dev.icerock.moko.resources", "StringResource"),
-                        )
-                        .build(),
-                )
-                .addProperty(
-                    PropertySpec.builder(
-                        "resourceId",
-                        ClassName("dev.icerock.moko.resources", "StringResource"),
-                    )
-                        .initializer("resourceId")
-                        .build(),
-                )
-                .addTypes(
-                    stringKeys.map { key ->
-                        TypeSpec.objectBuilder(toPascalCase(key))
-                            .addModifiers(KModifier.DATA)
-                            .superclass(ClassName(packageName, "StringResourceKey"))
-                            .addSuperclassConstructorParameter("%T.strings.%N", mrClass, key)
-                            .build()
-                    },
-                )
-                .build(),
-        )
-        .build()
+    ): FileSpec = resourceKeyFileSpec(
+        packageName = packageName,
+        className = "StringResourceKey",
+        resourceTypeName = "StringResource",
+        mrAccessor = "strings",
+        keys = stringKeys,
+        mrClass = mrClass,
+    )
 
-    private fun pluralsResourceKeyFileSpec(
+    internal fun pluralsResourceKeyFileSpec(
         packageName: String,
         pluralKeys: List<String>,
         mrClass: ClassName,
-    ): FileSpec = FileSpec.builder(packageName, "PluralsResourceKey")
-        .addType(
-            TypeSpec.classBuilder("PluralsResourceKey")
-                .addModifiers(KModifier.SEALED)
-                .primaryConstructor(
-                    FunSpec.constructorBuilder()
-                        .addParameter(
-                            "resourceId",
-                            ClassName("dev.icerock.moko.resources", "PluralsResource"),
-                        )
-                        .build(),
-                )
-                .addProperty(
-                    PropertySpec.builder(
-                        "resourceId",
-                        ClassName("dev.icerock.moko.resources", "PluralsResource"),
+    ): FileSpec = resourceKeyFileSpec(
+        packageName = packageName,
+        className = "PluralsResourceKey",
+        resourceTypeName = "PluralsResource",
+        mrAccessor = "plurals",
+        keys = pluralKeys,
+        mrClass = mrClass,
+    )
+
+    private fun resourceKeyFileSpec(
+        packageName: String,
+        className: String,
+        resourceTypeName: String,
+        mrAccessor: String,
+        keys: List<String>,
+        mrClass: ClassName,
+    ): FileSpec {
+        val resourceType = ClassName(MOKO_RESOURCES_PACKAGE, resourceTypeName)
+        val lazyResourceType = LAZY_CLASS.parameterizedBy(resourceType)
+
+        return FileSpec.builder(packageName, className)
+            .addType(
+                TypeSpec.classBuilder(className)
+                    .addModifiers(KModifier.SEALED)
+                    .primaryConstructor(
+                        FunSpec.constructorBuilder()
+                            .addParameter("resourceProvider", lazyResourceType)
+                            .build(),
                     )
-                        .initializer("resourceId")
-                        .build(),
-                )
-                .addTypes(
-                    pluralKeys.map { key ->
-                        TypeSpec.objectBuilder(toPascalCase(key))
-                            .addModifiers(KModifier.DATA)
-                            .superclass(ClassName(packageName, "PluralsResourceKey"))
-                            .addSuperclassConstructorParameter("%T.plurals.%N", mrClass, key)
-                            .build()
-                    },
-                )
-                .build(),
-        )
-        .build()
+                    .addProperty(
+                        PropertySpec.builder("resourceId", resourceType)
+                            .getter(
+                                FunSpec.getterBuilder()
+                                    .addStatement("return resourceProvider.value")
+                                    .build(),
+                            )
+                            .build(),
+                    )
+                    .addProperty(
+                        PropertySpec.builder("resourceProvider", lazyResourceType)
+                            .initializer("resourceProvider")
+                            .addModifiers(KModifier.PRIVATE)
+                            .build(),
+                    )
+                    .addTypes(
+                        keys.map { key ->
+                            TypeSpec.objectBuilder(toPascalCase(key))
+                                .addModifiers(KModifier.DATA)
+                                .superclass(ClassName(packageName, className))
+                                .addSuperclassConstructorParameter("lazy { %T.$mrAccessor.%N }", mrClass, key)
+                                .build()
+                        },
+                    )
+                    .build(),
+            )
+            .build()
+    }
+
+    private companion object {
+        const val MOKO_RESOURCES_PACKAGE = "dev.icerock.moko.resources"
+        val LAZY_CLASS = ClassName("kotlin", "Lazy")
+    }
 }

--- a/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTaskTest.kt
+++ b/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTaskTest.kt
@@ -1,0 +1,79 @@
+package io.github.thomaskioko.gradle.tasks
+
+import com.squareup.kotlinpoet.ClassName
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class MokoResourceGeneratorTaskTest {
+
+    private fun createTask(): MokoResourceGeneratorTask {
+        val project = ProjectBuilder.builder().build()
+        return project.tasks.register("generateMokoStrings", MokoResourceGeneratorTask::class.java).get()
+    }
+
+    private fun loadResource(path: String): String =
+        javaClass.classLoader.getResource(path)!!.readText()
+
+    private fun loadResourceFile(path: String): File =
+        File(javaClass.classLoader.getResource(path)!!.toURI())
+
+    @Test
+    fun `toPascalCase converts snake_case to PascalCase`() {
+        val task = createTask()
+        assertEquals("ButtonErrorRetry", task.toPascalCase("button_error_retry"))
+        assertEquals("AppName", task.toPascalCase("app_name"))
+        assertEquals("CdShowPoster", task.toPascalCase("cd_show_poster"))
+    }
+
+    @Test
+    fun `readKeysFromMRFile extracts string and plural keys`() {
+        val task = createTask()
+        val mrFile = loadResourceFile("moko-generator/MR.kt")
+
+        val (stringKeys, pluralKeys) = task.readKeysFromMRFile(mrFile)
+
+        assertEquals(
+            listOf("button_error_retry", "app_name", "label_discover_trending_today"),
+            stringKeys,
+        )
+        assertEquals(listOf("episode_count", "season_count"), pluralKeys)
+    }
+
+    @Test
+    fun `stringResourceKeyFileSpec matches expected output`() {
+        val task = createTask()
+        val packageName = "com.thomaskioko.tvmaniac.i18n"
+        val mrClass = ClassName(packageName, "MR")
+        val mrFile = loadResourceFile("moko-generator/MR.kt")
+        val (stringKeys, _) = task.readKeysFromMRFile(mrFile)
+
+        val fileSpec = task.stringResourceKeyFileSpec(
+            packageName = packageName,
+            stringKeys = stringKeys,
+            mrClass = mrClass,
+        )
+
+        val expected = loadResource("moko-generator/expected/StringResourceKey.kt")
+        assertEquals(expected, fileSpec.toString())
+    }
+
+    @Test
+    fun `pluralsResourceKeyFileSpec matches expected output`() {
+        val task = createTask()
+        val packageName = "com.thomaskioko.tvmaniac.i18n"
+        val mrClass = ClassName(packageName, "MR")
+        val mrFile = loadResourceFile("moko-generator/MR.kt")
+        val (_, pluralKeys) = task.readKeysFromMRFile(mrFile)
+
+        val fileSpec = task.pluralsResourceKeyFileSpec(
+            packageName = packageName,
+            pluralKeys = pluralKeys,
+            mrClass = mrClass,
+        )
+
+        val expected = loadResource("moko-generator/expected/PluralsResourceKey.kt")
+        assertEquals(expected, fileSpec.toString())
+    }
+}

--- a/plugins/src/test/resources/moko-generator/MR.kt
+++ b/plugins/src/test/resources/moko-generator/MR.kt
@@ -1,0 +1,16 @@
+package com.thomaskioko.tvmaniac.i18n
+
+import dev.icerock.moko.resources.PluralsResource
+import dev.icerock.moko.resources.StringResource
+
+public object MR {
+    public object strings {
+        public val button_error_retry: StringResource = StringResource()
+        public val app_name: StringResource = StringResource()
+        public val label_discover_trending_today: StringResource = StringResource()
+    }
+    public object plurals {
+        public val episode_count: PluralsResource = PluralsResource()
+        public val season_count: PluralsResource = PluralsResource()
+    }
+}

--- a/plugins/src/test/resources/moko-generator/expected/PluralsResourceKey.kt
+++ b/plugins/src/test/resources/moko-generator/expected/PluralsResourceKey.kt
@@ -1,0 +1,15 @@
+package com.thomaskioko.tvmaniac.i18n
+
+import dev.icerock.moko.resources.PluralsResource
+import kotlin.Lazy
+
+public sealed class PluralsResourceKey(
+  private val resourceProvider: Lazy<PluralsResource>,
+) {
+  public val resourceId: PluralsResource
+    get() = resourceProvider.value
+
+  public data object EpisodeCount : PluralsResourceKey(lazy { MR.plurals.episode_count })
+
+  public data object SeasonCount : PluralsResourceKey(lazy { MR.plurals.season_count })
+}

--- a/plugins/src/test/resources/moko-generator/expected/StringResourceKey.kt
+++ b/plugins/src/test/resources/moko-generator/expected/StringResourceKey.kt
@@ -1,0 +1,17 @@
+package com.thomaskioko.tvmaniac.i18n
+
+import dev.icerock.moko.resources.StringResource
+import kotlin.Lazy
+
+public sealed class StringResourceKey(
+  private val resourceProvider: Lazy<StringResource>,
+) {
+  public val resourceId: StringResource
+    get() = resourceProvider.value
+
+  public data object ButtonErrorRetry : StringResourceKey(lazy { MR.strings.button_error_retry })
+
+  public data object AppName : StringResourceKey(lazy { MR.strings.app_name })
+
+  public data object LabelDiscoverTrendingToday : StringResourceKey(lazy { MR.strings.label_discover_trending_today })
+}


### PR DESCRIPTION
## Changes
- Fix iOS test crashes (`FileFailedToInitializeException`) caused by eager `MR.strings` access in generated `StringResourceKey`/`PluralsResourceKey` sealed classes. Resource references are now lazily initialized.
- Copy moko resource bundles to iOS test binary output directories, enabling `i18n/implementation` tests to run on iOS without `@IgnoreIos`.
- Extract shared `resourceKeyFileSpec` to eliminate duplication between string and plural code generation.
- Remove dead incremental build logic from `MokoResourceGeneratorTask`; Gradle's built-in up-to-date checks via `@CacheableTask` handle this correctly.
- Scope `generateMokoStrings` task dependency to `commonMain` compilations only instead of all `KotlinCompile` tasks
- Fix temp directory leak in klib bundle extraction by using deterministic build directory paths.
- Add golden file tests for `MokoResourceGeneratorTask` code generation.