### PR TITLE
Add @ScreenUi and @SheetUi UI renderer codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+## 0.7.2 *(2026-04-18)*
+- Add support for UI renderer bindings
+
 ## 0.7.1 *(2026-04-17)*
 - Introduce a KSP-based navigation codegen that eliminates per-destination DI boilerplate in Metro + Decompose KMP projects.
 

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,7 +1,7 @@
 # Navigation Codegen
 
 KSP-based code generation for Kotlin Multiplatform navigation destinations built on Metro DI and Decompose. Eliminates the
-per-destination graph + binding boilerplate for screens, tabs, and modal sheets (bottom sheets, dialogs, or overlays) in a Metro-based navigation stack.
+per-destination graph + binding boilerplate for screens, tabs, and modal sheets (bottom sheets, dialogs, or overlays) in a Metro-based navigation stack, and the per-screen renderer binding boilerplate on the Android Compose layer.
 
 ## Docs
 

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/ScreenUi.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/ScreenUi.kt
@@ -1,0 +1,30 @@
+package io.github.thomaskioko.codegen.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Marks a `@Composable` screen function as the Android-side renderer for a root-stack presenter.
+ *
+ * The navigation codegen processor reads this annotation and generates, in the same `ui` module's
+ * `di/` package, a single binding:
+ *
+ * - `<FunctionName>UiBinding` — a `@BindingContainer @ContributesTo(parentScope)` object that
+ *   `@Provides @IntoSet` a consumer-project `ScreenContent` instance. The instance's `matches`
+ *   lambda tests whether the active `RootChild` is a `ScreenDestination<*>` wrapping the declared
+ *   [presenter] type, and its `content` lambda invokes the annotated composable with the cast
+ *   presenter and the incoming `Modifier`.
+ *
+ * The annotated function must match the signature
+ * `@Composable fun <Name>(presenter: <PresenterType>, modifier: Modifier = Modifier)`.
+ *
+ * @property presenter the presenter type this screen renders. Used to build the `matches` predicate
+ *                     and to cast the active child's presenter before invoking the composable.
+ * @property parentScope the parent DI scope hosting the generated binding. Typically
+ *                       `ActivityScope::class` in the consumer project.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class ScreenUi(
+    val presenter: KClass<*>,
+    val parentScope: KClass<*>,
+)

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/SheetUi.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/SheetUi.kt
@@ -1,0 +1,32 @@
+package io.github.thomaskioko.codegen.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Marks a `@Composable` sheet function as the Android-side renderer for a modal sheet presenter.
+ *
+ * The navigation codegen processor reads this annotation and generates, in the same `ui` module's
+ * `di/` package, a single binding:
+ *
+ * - `<FunctionName>UiBinding` — a `@BindingContainer @ContributesTo(parentScope)` object that
+ *   `@Provides @IntoSet` a consumer-project `SheetContent` instance. The instance's `matches`
+ *   lambda tests whether the active `SheetChild` is a `SheetDestination<*>` wrapping the declared
+ *   [presenter] type, and its `content` lambda invokes the annotated composable with the cast
+ *   presenter.
+ *
+ * The annotated function must match the signature
+ * `@Composable fun <Name>(presenter: <PresenterType>, modifier: Modifier = Modifier)`; only the
+ * `presenter` argument is forwarded by the generated code, since `SheetContent.content` does not
+ * receive a `Modifier`.
+ *
+ * @property presenter the presenter type this sheet renders. Used to build the `matches` predicate
+ *                     and to cast the active child's presenter before invoking the composable.
+ * @property parentScope the parent DI scope hosting the generated binding. Typically
+ *                       `ActivityScope::class` in the consumer project.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class SheetUi(
+    val presenter: KClass<*>,
+    val parentScope: KClass<*>,
+)

--- a/codegen/docs/annotations.md
+++ b/codegen/docs/annotations.md
@@ -1,6 +1,6 @@
 # Annotation Reference
 
-The annotations live in the `codegen-annotations` artifact under the package `io.github.thomaskioko.codegen.annotations`. All three have `SOURCE` retention and target classes only. This reference walks through each annotation, what it marks, what the processor emits, and the invariants the processor checks.
+The annotations live in the `codegen-annotations` artifact under the package `io.github.thomaskioko.codegen.annotations`. All five have `SOURCE` retention. Three (`@NavScreen`, `@TabScreen`, `@NavSheet`) target presenter classes in the shared KMP layer and generate Metro `@GraphExtension`s plus navigation bindings. Two (`@ScreenUi`, `@SheetUi`) target `@Composable` functions in Android `ui` modules and generate the platform-side renderer bindings consumed by the `Set<ScreenContent>` / `Set<SheetContent>` multibindings. This reference walks through each annotation, what it marks, what the processor emits, and the invariants the processor checks.
 
 
 ## `@NavScreen`
@@ -102,6 +102,56 @@ For `FooSheetPresenter` annotated with `route = FooSheetConfig::class`, the proc
 The sheet binding mirrors the `@NavScreen` pair. The child factory matches on the generic `SheetConfig` marker, casts to the feature's config type, and dispatches through the graph's assisted factory. The config binding feeds the polymorphic `KSerializer<SheetConfig>` used by Decompose's `childSlot`, so the sheet slot survives process death without a central registry.
 
 
+## `@ScreenUi`
+
+Marks a `@Composable` screen function as the Android-side renderer for a root-stack presenter. Unlike the three annotations above, this one targets the composable function directly so the generated binding lives in the same module as the composable it calls. No cross-module KSP emission is needed.
+
+```kotlin
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class ScreenUi(
+    val presenter: KClass<*>,
+    val parentScope: KClass<*>,
+)
+```
+
+The `presenter` parameter names the presenter type this screen renders. The processor uses it to build the `matches` predicate that tests whether the active `RootChild` is a `ScreenDestination<*>` wrapping an instance of that type, and to cast the presenter before forwarding it to the composable.
+
+The `parentScope` parameter names the DI scope the generated binding is contributed to. In Tv Maniac this is `ActivityScope::class`.
+
+### Processor behavior
+
+The annotated function must match the signature `@Composable fun <Name>(presenter: <PresenterType>, modifier: Modifier = Modifier)`. The processor does not enforce the `Modifier` parameter name or default, but the generated code calls the composable with `presenter = ..., modifier = modifier`, so the function must accept both in that order with those names.
+
+### Generated files
+
+For a composable `com.example.feature.ui.FooScreen` with `@ScreenUi(presenter = FooPresenter::class, parentScope = ActivityScope::class)`, the processor emits one file into `com.example.feature.ui.di`.
+
+`FooScreenUiBinding.kt` is a `@BindingContainer @ContributesTo(ActivityScope::class) object` that `@Provides @IntoSet` a single `ScreenContent`. The `matches` lambda tests `(it as? ScreenDestination<*>)?.presenter is FooPresenter`. The `content` lambda casts the child and invokes `FooScreen(presenter = ..., modifier = modifier)`.
+
+The `@BindingContainer + object` shape is deliberate. Hand-authored `@Provides @IntoSet` inside an `interface + companion object` requires Metro's `generateContributionProviders` flag to be enabled, which is disabled in the shared scaffold. Codegen-emitted bindings for the KMP presenter layer get away with the interface form because they are picked up by a separate code path. Bindings emitted into Android-only `ui` modules would silently produce an empty multibinding if the interface form were used, so the generator targets the object form instead.
+
+
+## `@SheetUi`
+
+Marks a `@Composable` sheet function as the Android-side renderer for a modal sheet presenter. Parallel to `@ScreenUi`, but targets the sheet-side multibinding `Set<SheetContent>` instead of the screen-side `Set<ScreenContent>`.
+
+```kotlin
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class SheetUi(
+    val presenter: KClass<*>,
+    val parentScope: KClass<*>,
+)
+```
+
+The parameters have the same meaning as on `@ScreenUi`. The generated `matches` predicate tests for a `SheetDestination<*>` (not `ScreenDestination<*>`), and the `content` lambda invokes the composable with `presenter` only. The sheet renderer does not receive a `Modifier` because `SheetContent.content` is `@Composable (SheetChild) -> Unit`; the sheet lays itself out via its own `ModalBottomSheet` (or equivalent) in the composable body.
+
+### Generated files
+
+For `EpisodeSheet` annotated with `@SheetUi(presenter = EpisodeSheetPresenter::class, parentScope = ActivityScope::class)`, the processor emits `EpisodeSheetUiBinding.kt`. Shape mirrors `@ScreenUi` output, differing only in return type (`SheetContent` vs `ScreenContent`) and the absence of the `modifier` forwarding.
+
+
 ## Required consumer primitives
 
 The generated code references fully qualified names that the consumer project must provide. These are hardcoded in the processor's `util/External.kt`, grouped below by the role they play.
@@ -111,5 +161,7 @@ The root destination shape pulls from `com.thomaskioko.tvmaniac.navigation`: `Na
 The sheet shape reuses that package for `SheetConfig` (the sheet config supertype), `SheetChild` (Decompose sheet child marker), `SheetDestination` (generic sheet wrapper), `SheetChildFactory` (sheet destination factory interface), and `SheetConfigBinding` (Metro multibinding entry for sheet configs).
 
 Tabs live under `com.thomaskioko.tvmaniac.home.nav`: `TabDestination` is the tab factory interface and `TabChild` is the generic tab wrapper. Finally, `com.thomaskioko.tvmaniac.core.base.ActivityScope` is the default parent scope referenced by the generated binding contributions.
+
+The platform-side UI renderer types live under `com.thomaskioko.tvmaniac.navigation.ui`: `ScreenContent` carries a `matches` predicate and a `@Composable (RootChild, Modifier) -> Unit` content lambda, and `SheetContent` does the same for `SheetChild`. The generated `@ScreenUi` / `@SheetUi` bindings also reference `androidx.compose.ui.Modifier` because the screen variant forwards a modifier into the composable.
 
 The processor is opinionated about these names. Consumers other than Tv Maniac would need to adjust `util/External.kt` to match their navigation primitives.

--- a/codegen/docs/examples.md
+++ b/codegen/docs/examples.md
@@ -250,3 +250,124 @@ public interface EpisodeDetailSheetDestinationBinding {
 Notice the shape is parallel to `@NavScreen`: a `@ContributesTo(parentScope)` interface whose companion contributes two `@IntoSet` providers. `SheetChildFactory` feeds the `Set<SheetChildFactory>` multibinding that the root presenter walks when the sheet slot activates. `SheetConfigBinding<*>` feeds the polymorphic `KSerializer<SheetConfig>` used by Decompose's `childSlot`, so the sheet slot survives process death without any central registry.
 
 The processor supports multiple `@Assisted` parameters for sheets. It maps each assisted constructor parameter to a route property by type and order.
+
+## Shape 5: `@ScreenUi`
+
+Use this shape on the Android `@Composable` that renders a root-stack screen. The annotation generates the small `ScreenContent` binding that joins the composable to the `Set<ScreenContent>` multibinding the root Compose stack iterates to pick the right renderer. One annotation replaces a small but entirely mechanical binding file per composable.
+
+### Input
+
+```kotlin
+package com.thomaskioko.tvmaniac.debug.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.debug.presenter.DebugPresenter
+import io.github.thomaskioko.codegen.annotations.ScreenUi
+
+@ScreenUi(presenter = DebugPresenter::class, parentScope = ActivityScope::class)
+@Composable
+public fun DebugMenuScreen(
+    presenter: DebugPresenter,
+    modifier: Modifier = Modifier,
+) {
+    // ...
+}
+```
+
+### Generated: `DebugMenuScreenUiBinding.kt`
+
+```kotlin
+package com.thomaskioko.tvmaniac.debug.ui.di
+
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.debug.presenter.DebugPresenter
+import com.thomaskioko.tvmaniac.debug.ui.DebugMenuScreen
+import com.thomaskioko.tvmaniac.navigation.ScreenDestination
+import com.thomaskioko.tvmaniac.navigation.ui.ScreenContent
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+
+@BindingContainer
+@ContributesTo(ActivityScope::class)
+public object DebugMenuScreenUiBinding {
+    @Provides
+    @IntoSet
+    public fun provideDebugMenuScreenContent(): ScreenContent = ScreenContent(
+        matches = { (it as? ScreenDestination<*>)?.presenter is DebugPresenter },
+        content = { child, modifier ->
+            DebugMenuScreen(
+                presenter = (child as ScreenDestination<*>).presenter as DebugPresenter,
+                modifier = modifier,
+            )
+        },
+    )
+}
+```
+
+Notice the `@BindingContainer + public object` shape rather than the `interface + companion object` used by `@NavScreen` output. The Android-only `ui` source set does not pick up authored `@Provides @IntoSet` declarations inside an interface companion unless Metro's `generateContributionProviders` is enabled, which is disabled in the shared scaffold. The generator targets the object form so the contribution is discovered without that flag. See the note in [annotations.md](annotations.md#screenui) for details.
+
+### Function shape invariant
+
+The annotated function must accept exactly two parameters: `presenter: <PresenterType>` first and `modifier: Modifier = Modifier` second. The generator calls them by name, so renaming either breaks the generated code at compile time.
+
+## Shape 6: `@SheetUi`
+
+Use this shape on the Android `@Composable` that renders a modal sheet. Parallel to `@ScreenUi`, but contributes a `SheetContent` into `Set<SheetContent>` instead of a `ScreenContent` into `Set<ScreenContent>`.
+
+### Input
+
+```kotlin
+package com.thomaskioko.tvmaniac.episodedetail.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.presentation.episodedetail.EpisodeSheetPresenter
+import io.github.thomaskioko.codegen.annotations.SheetUi
+
+@SheetUi(presenter = EpisodeSheetPresenter::class, parentScope = ActivityScope::class)
+@Composable
+public fun EpisodeSheet(
+    presenter: EpisodeSheetPresenter,
+    modifier: Modifier = Modifier,
+) {
+    // ...
+}
+```
+
+### Generated: `EpisodeSheetUiBinding.kt`
+
+```kotlin
+package com.thomaskioko.tvmaniac.episodedetail.ui.di
+
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.episodedetail.ui.EpisodeSheet
+import com.thomaskioko.tvmaniac.navigation.SheetDestination
+import com.thomaskioko.tvmaniac.navigation.ui.SheetContent
+import com.thomaskioko.tvmaniac.presentation.episodedetail.EpisodeSheetPresenter
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+
+@BindingContainer
+@ContributesTo(ActivityScope::class)
+public object EpisodeSheetUiBinding {
+    @Provides
+    @IntoSet
+    public fun provideEpisodeSheetContent(): SheetContent = SheetContent(
+        matches = { (it as? SheetDestination<*>)?.presenter is EpisodeSheetPresenter },
+        content = { child ->
+            EpisodeSheet(
+                presenter = (child as SheetDestination<*>).presenter as EpisodeSheetPresenter,
+            )
+        },
+    )
+}
+```
+
+The sheet renderer receives no `Modifier`. `SheetContent.content` is `@Composable (SheetChild) -> Unit`; the modal presentation (`ModalBottomSheet` or similar) is set up inside the composable body. The annotated function still accepts a `modifier: Modifier = Modifier` parameter for consistency with other composables, but the generator does not forward it.

--- a/codegen/docs/get-started.md
+++ b/codegen/docs/get-started.md
@@ -49,7 +49,6 @@ Android UI renderer annotations (target `FUNCTION`, live in the Android `ui` mod
    }
 
    scaffold {
-       useMetro()
        useCodegen()
 
        android {

--- a/codegen/docs/get-started.md
+++ b/codegen/docs/get-started.md
@@ -1,28 +1,35 @@
 # Get started
 
-Codegen is a KSP processor that eliminates the per-destination DI boilerplate for screens, tabs, and modal sheets (bottom sheets, dialogs, or overlays presented via Decompose's `childSlot`) in a Metro + Decompose Kotlin Multiplatform app. One annotation on the presenter generates both the Metro `@GraphExtension` graph and the binding that contributes it into the navigation multibinding.
+Codegen is a KSP processor that eliminates the per-destination DI boilerplate for screens, tabs, modal sheets (bottom sheets, dialogs, or overlays presented via Decompose's `childSlot`), and the Android platform-side renderer bindings that wire composables into the root Compose stack. A single annotation replaces a manually authored Metro `@GraphExtension` plus binding, or a manually authored `ScreenContent` / `SheetContent` multibinding contribution.
 
 ## Why it exists
 
-Each root destination in a Metro + Decompose KMP app hand-writes three artifacts:
+Each root destination in a Metro + Decompose KMP app needs three artifacts written manually:
 
-1. `FooRoute` in `nav/api` — the feature's public API, stays hand-written.
+1. `FooRoute` in `nav/api` — the feature's public API, stays manual.
 2. `FooScreenGraph` in `presenter/di` — Metro `@GraphExtension`.
 3. `FooNavDestinationBinding` in `presenter/di` — contributes `NavDestination` + `NavRouteBinding` to the Metro multibinding.
 
-The graph and binding are mechanical and derive entirely from the presenter + route. The codegen generates both from a single annotation. The route stays hand-written because it is the feature's public API, and it doubles as the `@GraphExtension` scope marker — no separate scope class is generated.
+The graph and binding are mechanical and derive entirely from the presenter + route. Separately, each Android Compose screen needs a small renderer binding that contributes a `ScreenContent` (or `SheetContent`) into the activity-scope multibinding consumed by the root Compose stack. That binding is also mechanical and derives entirely from the composable + presenter type. The codegen generates all of the above from a single annotation per artifact. The route and the composable stay manual because they are the feature's public API; the route doubles as the `@GraphExtension` scope marker, and the composable is the entry point the annotation is placed on.
 
 ## Supported annotation shapes
 
-Three annotations cover the navigation shapes the processor knows how to generate. See [annotations.md](annotations.md) for the full reference and [examples.md](examples.md) for concrete inputs and outputs.
+Five annotations cover the shapes the processor knows how to generate. See [annotations.md](annotations.md) for the full reference and [examples.md](examples.md) for concrete inputs and outputs.
+
+Shared-code presenter annotations (target `CLASS`, live in the KMP `presenter` module):
 
 1. `@NavScreen` marks a root destination (simple or parameterized). It generates a graph scoped to the route plus a binding that contributes `NavDestination` and `NavRouteBinding` into the Metro multibindings. The processor auto-detects `@AssistedInject` and a nested `@AssistedFactory` to switch between the simple and parameterized generation paths.
 2. `@TabScreen` marks a home tab destination. It generates a graph scoped to the config plus a binding that contributes `TabDestination`. No `NavRouteBinding` is emitted because the host feature owns its own config serialization.
-3. `@NavSheet` marks a modal sheet destination — a bottom sheet, dialog, or overlay presented on top of the current destination through Decompose's `childSlot`. It generates a graph scoped to the config plus a binding that contributes `SheetChildFactory` and `SheetConfigBinding`.
+3. `@NavSheet` marks a modal sheet destination, a bottom sheet, dialog, or overlay presented on top of the current destination through Decompose's `childSlot`. It generates a graph scoped to the config plus a binding that contributes `SheetChildFactory` and `SheetConfigBinding`.
+
+Android UI renderer annotations (target `FUNCTION`, live in the Android `ui` module):
+
+4. `@ScreenUi` marks a `@Composable` screen function as the Android-side renderer for a root-stack presenter. It generates a `@BindingContainer` object contributing a `ScreenContent` into `Set<ScreenContent>` so the root Compose stack can iterate the set and dispatch to the right screen.
+5. `@SheetUi` marks a `@Composable` sheet function as the Android-side renderer for a modal sheet presenter. Parallel to `@ScreenUi` but contributes a `SheetContent` into `Set<SheetContent>`.
 
 ## Dependency
 
-1. Apply the plugin DSL in a presenter module's `build.gradle.kts`:
+1. Apply the plugin DSL. In a KMP presenter module's `build.gradle.kts`:
 
    ```kotlin
    plugins {
@@ -34,7 +41,24 @@ Three annotations cover the navigation shapes the processor knows how to generat
    }
    ```
 
-   `useCodegen()` is defined on `BaseExtension` in `plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt`. It applies `com.google.devtools.ksp`, adds `codegen-annotations` to `commonMainImplementation`, and registers `codegen-processor` as a KSP processor for every KMP target.
+   Same call in an Android `ui` module when using `@ScreenUi` / `@SheetUi`:
+
+   ```kotlin
+   plugins {
+       alias(libs.plugins.app.android)
+   }
+
+   scaffold {
+       useMetro()
+       useCodegen()
+
+       android {
+           useCompose()
+       }
+   }
+   ```
+
+   `useCodegen()` is defined on `BaseExtension` in `plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt`. It applies `com.google.devtools.ksp`, adds `codegen-annotations` to the appropriate implementation configuration, and registers `codegen-processor` as a KSP processor for every target in the module.
 
 2. Declare the two library entries in the consumer's `libs.versions.toml` so the DSL can resolve them via the version catalog:
 
@@ -46,7 +70,7 @@ Three annotations cover the navigation shapes the processor knows how to generat
 
 ## Basic usage
 
-Annotate the presenter:
+Annotate the presenter (shared KMP layer):
 
 ```kotlin
 @Inject
@@ -54,7 +78,20 @@ Annotate the presenter:
 public class DebugPresenter(...) : ComponentContext by componentContext
 ```
 
-Build the module. KSP generates the graph and binding into the presenter module's `di/` package. No further wiring is required.
+Annotate the matching composable (Android ui layer):
+
+```kotlin
+@ScreenUi(presenter = DebugPresenter::class, parentScope = ActivityScope::class)
+@Composable
+public fun DebugMenuScreen(
+    presenter: DebugPresenter,
+    modifier: Modifier = Modifier,
+) { ... }
+```
+
+Build the modules. KSP generates the graph + nav binding into the presenter module's `di/` package, and the `ScreenContent` binding into the ui module's `di/` package. No further wiring is required inside each module.
+
+For the `@ScreenUi` / `@SheetUi` contributions to be picked up by the app's Metro graph, the app module must declare a direct `implementation` dependency on each feature `ui` module. Transitive `implementation` dependencies through a root ui module do not expose the generated `metro/hints/` classes on the app's compile classpath, and Metro will report the multibinding as unexpectedly empty at build time.
 
 ## References
 
@@ -63,4 +100,3 @@ Build the module. KSP generates the graph and binding into the presenter module'
 - KSP: https://kotlinlang.org/docs/ksp-overview.html
 - kctfork: https://github.com/ZacSweers/kotlin-compile-testing
 - KotlinPoet: https://square.github.io/kotlinpoet/
-

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/ScreenUiTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/ScreenUiTest.kt
@@ -1,0 +1,58 @@
+package io.github.thomaskioko.codegen.processor
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCompilerApi::class)
+class ScreenUiTest {
+
+    @Test
+    fun `should generate ScreenContent binding for ScreenUi composable`() {
+        val sources = TestStubs.uiStubs.toMap() + mapOf(
+            "DebugPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.debug.presenter
+
+                public class DebugPresenter
+            """.trimIndent(),
+            "DebugMenuScreen.kt" to """
+                package com.thomaskioko.tvmaniac.debug.ui
+
+                import androidx.compose.ui.Composable
+                import androidx.compose.ui.Modifier
+                import com.thomaskioko.tvmaniac.core.base.ActivityScope
+                import com.thomaskioko.tvmaniac.debug.presenter.DebugPresenter
+                import io.github.thomaskioko.codegen.annotations.ScreenUi
+
+                @ScreenUi(presenter = DebugPresenter::class, parentScope = ActivityScope::class)
+                @Composable
+                public fun DebugMenuScreen(
+                    presenter: DebugPresenter,
+                    modifier: Modifier = Modifier,
+                ) {
+                }
+            """.trimIndent(),
+        )
+
+        val result = ProcessorTestRunner().run(sources)
+        assertEquals(
+            "Compilation failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+        )
+
+        val files = result.generatedFiles
+        assertEquals(
+            "Expected exactly 1 generated file, got ${files.keys}",
+            setOf("DebugMenuScreenUiBinding.kt"),
+            files.keys,
+        )
+
+        GoldenFileAssert.assertMatches(
+            "screen-ui",
+            "DebugMenuScreenUiBinding.kt",
+            files.getValue("DebugMenuScreenUiBinding.kt"),
+        )
+    }
+}

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/SheetUiTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/SheetUiTest.kt
@@ -1,0 +1,58 @@
+package io.github.thomaskioko.codegen.processor
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCompilerApi::class)
+class SheetUiTest {
+
+    @Test
+    fun `should generate SheetContent binding for SheetUi composable`() {
+        val sources = TestStubs.uiStubs.toMap() + mapOf(
+            "EpisodeSheetPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presentation.episodedetail
+
+                public class EpisodeSheetPresenter
+            """.trimIndent(),
+            "EpisodeSheet.kt" to """
+                package com.thomaskioko.tvmaniac.episodedetail.ui
+
+                import androidx.compose.ui.Composable
+                import androidx.compose.ui.Modifier
+                import com.thomaskioko.tvmaniac.core.base.ActivityScope
+                import com.thomaskioko.tvmaniac.presentation.episodedetail.EpisodeSheetPresenter
+                import io.github.thomaskioko.codegen.annotations.SheetUi
+
+                @SheetUi(presenter = EpisodeSheetPresenter::class, parentScope = ActivityScope::class)
+                @Composable
+                public fun EpisodeSheet(
+                    presenter: EpisodeSheetPresenter,
+                    modifier: Modifier = Modifier,
+                ) {
+                }
+            """.trimIndent(),
+        )
+
+        val result = ProcessorTestRunner().run(sources)
+        assertEquals(
+            "Compilation failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+        )
+
+        val files = result.generatedFiles
+        assertEquals(
+            "Expected exactly 1 generated file, got ${files.keys}",
+            setOf("EpisodeSheetUiBinding.kt"),
+            files.keys,
+        )
+
+        GoldenFileAssert.assertMatches(
+            "sheet-ui",
+            "EpisodeSheetUiBinding.kt",
+            files.getValue("EpisodeSheetUiBinding.kt"),
+        )
+    }
+}

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/TestStubs.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/TestStubs.kt
@@ -125,11 +125,44 @@ internal object TestStubs {
         @Target(AnnotationTarget.CLASS)
         public annotation class ContributesBinding(val scope: KClass<*>)
 
+        @Target(AnnotationTarget.CLASS)
+        public annotation class BindingContainer
+
         @Target(AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
         public annotation class Provides
 
         @Target(AnnotationTarget.FUNCTION)
         public annotation class IntoSet
+    """.trimIndent()
+
+    val composeUi = "ComposeUi.kt" to """
+        package androidx.compose.ui
+
+        public interface Modifier {
+            public companion object : Modifier
+        }
+
+        @Target(AnnotationTarget.FUNCTION, AnnotationTarget.TYPE, AnnotationTarget.PROPERTY_GETTER)
+        public annotation class Composable
+    """.trimIndent()
+
+    val navigationUi = "NavigationUi.kt" to """
+        package com.thomaskioko.tvmaniac.navigation.ui
+
+        import androidx.compose.ui.Composable
+        import androidx.compose.ui.Modifier
+        import com.thomaskioko.tvmaniac.navigation.RootChild
+        import com.thomaskioko.tvmaniac.navigation.SheetChild
+
+        public class ScreenContent(
+            public val matches: (RootChild) -> Boolean,
+            public val content: @Composable (RootChild, Modifier) -> Unit,
+        )
+
+        public class SheetContent(
+            public val matches: (SheetChild) -> Boolean,
+            public val content: @Composable (SheetChild) -> Unit,
+        )
     """.trimIndent()
 
     val baseStubs: List<Pair<String, String>> = listOf(
@@ -141,4 +174,6 @@ internal object TestStubs {
     )
 
     val tabStubs: List<Pair<String, String>> = baseStubs + listOf(homeNav, homeConfig)
+
+    val uiStubs: List<Pair<String, String>> = baseStubs + listOf(composeUi, navigationUi)
 }

--- a/codegen/processor-test/src/test/resources/golden/screen-ui/DebugMenuScreenUiBinding.kt
+++ b/codegen/processor-test/src/test/resources/golden/screen-ui/DebugMenuScreenUiBinding.kt
@@ -1,0 +1,27 @@
+package com.thomaskioko.tvmaniac.debug.ui.di
+
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.debug.presenter.DebugPresenter
+import com.thomaskioko.tvmaniac.debug.ui.DebugMenuScreen
+import com.thomaskioko.tvmaniac.navigation.ScreenDestination
+import com.thomaskioko.tvmaniac.navigation.ui.ScreenContent
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+
+@BindingContainer
+@ContributesTo(ActivityScope::class)
+public object DebugMenuScreenUiBinding {
+    @Provides
+    @IntoSet
+    public fun provideDebugMenuScreenContent(): ScreenContent = ScreenContent(
+        matches = { (it as? ScreenDestination<*>)?.presenter is DebugPresenter },
+        content = { child, modifier ->
+            DebugMenuScreen(
+                presenter = (child as ScreenDestination<*>).presenter as DebugPresenter,
+                modifier = modifier,
+            )
+        },
+    )
+}

--- a/codegen/processor-test/src/test/resources/golden/sheet-ui/EpisodeSheetUiBinding.kt
+++ b/codegen/processor-test/src/test/resources/golden/sheet-ui/EpisodeSheetUiBinding.kt
@@ -1,0 +1,26 @@
+package com.thomaskioko.tvmaniac.episodedetail.ui.di
+
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.episodedetail.ui.EpisodeSheet
+import com.thomaskioko.tvmaniac.navigation.SheetDestination
+import com.thomaskioko.tvmaniac.navigation.ui.SheetContent
+import com.thomaskioko.tvmaniac.presentation.episodedetail.EpisodeSheetPresenter
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+
+@BindingContainer
+@ContributesTo(ActivityScope::class)
+public object EpisodeSheetUiBinding {
+    @Provides
+    @IntoSet
+    public fun provideEpisodeSheetContent(): SheetContent = SheetContent(
+        matches = { (it as? SheetDestination<*>)?.presenter is EpisodeSheetPresenter },
+        content = { child ->
+            EpisodeSheet(
+                presenter = (child as SheetDestination<*>).presenter as EpisodeSheetPresenter,
+            )
+        },
+    )
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/Constants.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/Constants.kt
@@ -5,10 +5,14 @@ internal object Constants {
     const val NAV_SCREEN: String = "NavScreen"
     const val TAB_SCREEN: String = "TabScreen"
     const val NAV_SHEET: String = "NavSheet"
+    const val SCREEN_UI: String = "ScreenUi"
+    const val SHEET_UI: String = "SheetUi"
 
     const val NAV_SCREEN_FQN: String = "$ANNOTATIONS_PACKAGE.$NAV_SCREEN"
     const val TAB_SCREEN_FQN: String = "$ANNOTATIONS_PACKAGE.$TAB_SCREEN"
     const val NAV_SHEET_FQN: String = "$ANNOTATIONS_PACKAGE.$NAV_SHEET"
+    const val SCREEN_UI_FQN: String = "$ANNOTATIONS_PACKAGE.$SCREEN_UI"
+    const val SHEET_UI_FQN: String = "$ANNOTATIONS_PACKAGE.$SHEET_UI"
 
     const val METRO_PACKAGE: String = "dev.zacsweers.metro"
     const val ASSISTED_FACTORY_FQN: String = "$METRO_PACKAGE.AssistedFactory"

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessor.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessor.kt
@@ -7,27 +7,61 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ksp.writeTo
 import io.github.thomaskioko.codegen.processor.codegen.FileGenerator
+import io.github.thomaskioko.codegen.processor.codegen.UiBindingGenerator
 import io.github.thomaskioko.codegen.processor.data.NavData
+import io.github.thomaskioko.codegen.processor.data.UiBindingKind
 import io.github.thomaskioko.codegen.processor.parser.findNestedAssistedFactory
-import io.github.thomaskioko.codegen.processor.parser.parseParameterizedScreenData
+import io.github.thomaskioko.codegen.processor.parser.parseScreenData
 import io.github.thomaskioko.codegen.processor.parser.parseSheetData
-import io.github.thomaskioko.codegen.processor.parser.parseSimpleScreenData
 import io.github.thomaskioko.codegen.processor.parser.parseTabData
+import io.github.thomaskioko.codegen.processor.parser.parseUiBindingData
 
 public class NavigationCodegenProcessor(
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger,
 ) : SymbolProcessor {
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        processAnnotation(resolver, Constants.NAV_SCREEN_FQN, Constants.NAV_SCREEN, ::parseNavScreen)
+        processAnnotation(resolver, Constants.NAV_SCREEN_FQN, Constants.NAV_SCREEN) { presenter ->
+            parseScreenData(presenter, logger)
+        }
         processAnnotation(resolver, Constants.TAB_SCREEN_FQN, Constants.TAB_SCREEN) { presenter ->
             parseTabData(presenter, logger)
         }
         processAnnotation(resolver, Constants.NAV_SHEET_FQN, Constants.NAV_SHEET, ::parseNavSheet)
+        processUiBinding(resolver, Constants.SCREEN_UI_FQN, Constants.SCREEN_UI, UiBindingKind.Screen)
+        processUiBinding(resolver, Constants.SHEET_UI_FQN, Constants.SHEET_UI, UiBindingKind.Sheet)
         return emptyList()
+    }
+
+    private fun processUiBinding(
+        resolver: Resolver,
+        fqn: String,
+        shortName: String,
+        kind: UiBindingKind,
+    ) {
+        for (symbol in resolver.getSymbolsWithAnnotation(fqn)) {
+            val function = symbol as? KSFunctionDeclaration ?: run {
+                logger.error("@$shortName can only be applied to functions", symbol)
+                continue
+            }
+            val data = parseUiBindingData(function, kind, logger) ?: continue
+            writeFunctionFiles(function, listOf(UiBindingGenerator.generate(data)))
+        }
+    }
+
+    private fun writeFunctionFiles(source: KSFunctionDeclaration, files: List<FileSpec>) {
+        val containingFile = source.containingFile ?: run {
+            logger.warn("Cannot determine containing file for ${source.qualifiedName?.asString()}", source)
+            return
+        }
+        val deps = Dependencies(aggregating = false, containingFile)
+        for (file in files) {
+            file.writeTo(codeGenerator, deps)
+        }
     }
 
     private fun processAnnotation(
@@ -43,15 +77,6 @@ public class NavigationCodegenProcessor(
             }
             val data = parse(declaration) ?: continue
             writeFiles(declaration, FileGenerator.generate(data))
-        }
-    }
-
-    private fun parseNavScreen(presenter: KSClassDeclaration): NavData? {
-        val nestedFactory = presenter.findNestedAssistedFactory()
-        return if (nestedFactory == null) {
-            parseSimpleScreenData(presenter, logger)
-        } else {
-            parseParameterizedScreenData(presenter, nestedFactory, logger)
         }
     }
 

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/BindingFiles.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/BindingFiles.kt
@@ -1,0 +1,37 @@
+package io.github.thomaskioko.codegen.processor.codegen
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeSpec
+import io.github.thomaskioko.codegen.processor.util.FOUR_SPACE_INDENT
+import io.github.thomaskioko.codegen.processor.util.contributesTo
+
+/**
+ * Builds a `@ContributesTo(parentScope) public interface [bindingName] { public companion object { ... } }`
+ * file with the given [providers] in the companion. Used by every destination-binding generator
+ * (`NavDestinationBindingGenerator`, `SheetDestinationBindingGenerator`,
+ * `TabDestinationBindingGenerator`) so they don't each spell the scaffold out by hand.
+ */
+internal fun contributingBindingFile(
+    bindingName: ClassName,
+    parentScope: ClassName,
+    vararg providers: FunSpec,
+): FileSpec {
+    val companion = TypeSpec.companionObjectBuilder()
+        .addModifiers(KModifier.PUBLIC)
+        .also { builder -> providers.forEach { builder.addFunction(it) } }
+        .build()
+
+    val bindingInterface = TypeSpec.interfaceBuilder(bindingName)
+        .addModifiers(KModifier.PUBLIC)
+        .addAnnotation(contributesTo(parentScope))
+        .addType(companion)
+        .build()
+
+    return FileSpec.builder(bindingName)
+        .indent(FOUR_SPACE_INDENT)
+        .addType(bindingInterface)
+        .build()
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/FileGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/FileGenerator.kt
@@ -2,18 +2,13 @@ package io.github.thomaskioko.codegen.processor.codegen
 
 import com.squareup.kotlinpoet.FileSpec
 import io.github.thomaskioko.codegen.processor.data.NavData
-import io.github.thomaskioko.codegen.processor.data.ParameterizedScreenData
+import io.github.thomaskioko.codegen.processor.data.ScreenData
 import io.github.thomaskioko.codegen.processor.data.SheetData
-import io.github.thomaskioko.codegen.processor.data.SimpleScreenData
 import io.github.thomaskioko.codegen.processor.data.TabData
 
 internal object FileGenerator {
     fun generate(data: NavData): List<FileSpec> = when (data) {
-        is SimpleScreenData -> listOf(
-            ScreenGraphGenerator.generate(data),
-            NavDestinationBindingGenerator.generate(data),
-        )
-        is ParameterizedScreenData -> listOf(
+        is ScreenData -> listOf(
             ScreenGraphGenerator.generate(data),
             NavDestinationBindingGenerator.generate(data),
         )

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/NavDestinationBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/NavDestinationBindingGenerator.kt
@@ -5,11 +5,8 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.TypeSpec
-import io.github.thomaskioko.codegen.processor.data.ParameterizedScreenData
-import io.github.thomaskioko.codegen.processor.data.SimpleScreenData
+import io.github.thomaskioko.codegen.processor.data.ScreenData
 import io.github.thomaskioko.codegen.processor.util.ComponentContext
-import io.github.thomaskioko.codegen.processor.util.FOUR_SPACE_INDENT
 import io.github.thomaskioko.codegen.processor.util.IntoSet
 import io.github.thomaskioko.codegen.processor.util.NavDestination
 import io.github.thomaskioko.codegen.processor.util.NavRoute
@@ -17,116 +14,66 @@ import io.github.thomaskioko.codegen.processor.util.NavRouteBinding
 import io.github.thomaskioko.codegen.processor.util.Provides
 import io.github.thomaskioko.codegen.processor.util.RootChild
 import io.github.thomaskioko.codegen.processor.util.ScreenDestination
-import io.github.thomaskioko.codegen.processor.util.contributesTo
 import io.github.thomaskioko.codegen.processor.util.parameterizedByStar
 
 internal object NavDestinationBindingGenerator {
-    fun generate(data: SimpleScreenData): FileSpec = buildBindingFile(
+    fun generate(data: ScreenData): FileSpec = contributingBindingFile(
         bindingName = data.bindingClassName,
         parentScope = data.parentScope,
-        provideDestination = simpleDestinationFun(data),
-        provideRouteBinding = routeBindingFun(data.baseName, data.route),
+        destinationFun(data),
+        routeBindingFun(data.baseName, data.route),
     )
 
-    fun generate(data: ParameterizedScreenData): FileSpec = buildBindingFile(
-        bindingName = data.bindingClassName,
-        parentScope = data.parentScope,
-        provideDestination = parameterizedDestinationFun(data),
-        provideRouteBinding = routeBindingFun(data.baseName, data.route),
-    )
-
-    private fun buildBindingFile(
-        bindingName: ClassName,
-        parentScope: ClassName,
-        provideDestination: FunSpec,
-        provideRouteBinding: FunSpec,
-    ): FileSpec {
-        val companion = TypeSpec.companionObjectBuilder()
-            .addModifiers(KModifier.PUBLIC)
-            .addFunction(provideDestination)
-            .addFunction(provideRouteBinding)
-            .build()
-
-        val bindingInterface = TypeSpec.interfaceBuilder(bindingName)
-            .addModifiers(KModifier.PUBLIC)
-            .addAnnotation(contributesTo(parentScope))
-            .addType(companion)
-            .build()
-
-        return FileSpec.builder(bindingName)
-            .indent(FOUR_SPACE_INDENT)
-            .addType(bindingInterface)
-            .build()
-    }
-
-    private fun simpleDestinationFun(data: SimpleScreenData): FunSpec =
+    private fun destinationFun(data: ScreenData): FunSpec =
         FunSpec.builder("provide${data.baseName}NavDestination")
             .addModifiers(KModifier.PUBLIC)
             .addAnnotation(Provides)
             .addAnnotation(IntoSet)
             .addParameter("graphFactory", data.graphFactoryClassName)
             .returns(NavDestination)
-            .addCode(
-                CodeBlock.builder()
-                    .add("return object : %T {\n", NavDestination)
-                    .indent()
-                    .add("override fun matches(route: %T): Boolean = route is %T\n\n", NavRoute, data.route)
-                    .add("override fun createChild(\n")
-                    .indent()
-                    .add("route: %T,\n", NavRoute)
-                    .add("componentContext: %T,\n", ComponentContext)
-                    .unindent()
-                    .add("): %T = %T(\n", RootChild, ScreenDestination)
-                    .indent()
-                    .add(
-                        "presenter = graphFactory.%L(componentContext).%L,\n",
-                        data.graphFactoryFunName,
-                        data.graphPropertyName,
-                    )
-                    .unindent()
-                    .add(")\n")
-                    .unindent()
-                    .add("}\n")
-                    .build(),
-            )
+            .addCode(destinationBody(data))
             .build()
 
-    private fun parameterizedDestinationFun(data: ParameterizedScreenData): FunSpec {
-        val routeLocalName = data.route.simpleName.replaceFirstChar { it.lowercaseChar() }
-        return FunSpec.builder("provide${data.baseName}NavDestination")
-            .addModifiers(KModifier.PUBLIC)
-            .addAnnotation(Provides)
-            .addAnnotation(IntoSet)
-            .addParameter("graphFactory", data.graphFactoryClassName)
-            .returns(NavDestination)
-            .addCode(
-                CodeBlock.builder()
-                    .add("return object : %T {\n", NavDestination)
-                    .indent()
-                    .add("override fun matches(route: %T): Boolean = route is %T\n\n", NavRoute, data.route)
-                    .add("override fun createChild(\n")
-                    .indent()
-                    .add("route: %T,\n", NavRoute)
-                    .add("componentContext: %T,\n", ComponentContext)
-                    .unindent()
-                    .add("): %T {\n", RootChild)
-                    .indent()
-                    .add("val %L = route as %T\n", routeLocalName, data.route)
-                    .add("val graph = graphFactory.%L(componentContext)\n", data.graphFactoryFunName)
-                    .add(
-                        "return %T(graph.%L.create(%L.%L))\n",
-                        ScreenDestination,
-                        data.graphPropertyName,
-                        routeLocalName,
-                        data.routeProperty,
-                    )
-                    .unindent()
-                    .add("}\n")
-                    .unindent()
-                    .add("}\n")
-                    .build(),
-            )
-            .build()
+    private fun destinationBody(data: ScreenData): CodeBlock {
+        val builder = CodeBlock.builder()
+            .add("return object : %T {\n", NavDestination)
+            .indent()
+            .add("override fun matches(route: %T): Boolean = route is %T\n\n", NavRoute, data.route)
+            .add("override fun createChild(\n")
+            .indent()
+            .add("route: %T,\n", NavRoute)
+            .add("componentContext: %T,\n", ComponentContext)
+            .unindent()
+        if (data.isParameterized) {
+            val routeLocal = data.route.simpleName.replaceFirstChar { it.lowercaseChar() }
+            builder
+                .add("): %T {\n", RootChild)
+                .indent()
+                .add("val %L = route as %T\n", routeLocal, data.route)
+                .add("val graph = graphFactory.%L(componentContext)\n", data.graphFactoryFunName)
+                .add(
+                    "return %T(graph.%L.create(%L.%L))\n",
+                    ScreenDestination,
+                    data.graphPropertyName,
+                    routeLocal,
+                    data.routeProperty,
+                )
+                .unindent()
+                .add("}\n")
+        } else {
+            builder
+                .add("): %T = %T(\n", RootChild, ScreenDestination)
+                .indent()
+                .add(
+                    "presenter = graphFactory.%L(componentContext).%L,\n",
+                    data.graphFactoryFunName,
+                    data.graphPropertyName,
+                )
+                .unindent()
+                .add(")\n")
+        }
+        builder.unindent().add("}\n")
+        return builder.build()
     }
 
     private fun routeBindingFun(baseName: String, route: ClassName): FunSpec =

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/SheetDestinationBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/SheetDestinationBindingGenerator.kt
@@ -4,10 +4,8 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.TypeSpec
 import io.github.thomaskioko.codegen.processor.data.SheetData
 import io.github.thomaskioko.codegen.processor.util.ComponentContext
-import io.github.thomaskioko.codegen.processor.util.FOUR_SPACE_INDENT
 import io.github.thomaskioko.codegen.processor.util.IntoSet
 import io.github.thomaskioko.codegen.processor.util.Provides
 import io.github.thomaskioko.codegen.processor.util.SheetChild
@@ -15,11 +13,17 @@ import io.github.thomaskioko.codegen.processor.util.SheetChildFactory
 import io.github.thomaskioko.codegen.processor.util.SheetConfig
 import io.github.thomaskioko.codegen.processor.util.SheetConfigBinding
 import io.github.thomaskioko.codegen.processor.util.SheetDestination
-import io.github.thomaskioko.codegen.processor.util.contributesTo
 import io.github.thomaskioko.codegen.processor.util.parameterizedByStar
 
 internal object SheetDestinationBindingGenerator {
-    fun generate(data: SheetData): FileSpec {
+    fun generate(data: SheetData): FileSpec = contributingBindingFile(
+        bindingName = data.bindingClassName,
+        parentScope = data.parentScope,
+        childFactoryFun(data),
+        configBindingFun(data),
+    )
+
+    private fun childFactoryFun(data: SheetData): FunSpec {
         val createCallArgs = CodeBlock.builder().apply {
             data.assistedMappings.forEachIndexed { index, mapping ->
                 if (index > 0) add(", ")
@@ -27,7 +31,7 @@ internal object SheetDestinationBindingGenerator {
             }
         }.build()
 
-        val provideChildFactoryFun = FunSpec.builder("provide${data.baseName}ChildFactory")
+        return FunSpec.builder("provide${data.baseName}ChildFactory")
             .addModifiers(KModifier.PUBLIC)
             .addAnnotation(Provides)
             .addAnnotation(IntoSet)
@@ -63,8 +67,10 @@ internal object SheetDestinationBindingGenerator {
                     .build(),
             )
             .build()
+    }
 
-        val provideConfigBindingFun = FunSpec.builder("provide${data.baseName}ConfigBinding")
+    private fun configBindingFun(data: SheetData): FunSpec =
+        FunSpec.builder("provide${data.baseName}ConfigBinding")
             .addModifiers(KModifier.PUBLIC)
             .addAnnotation(Provides)
             .addAnnotation(IntoSet)
@@ -76,22 +82,4 @@ internal object SheetDestinationBindingGenerator {
                 data.scope,
             )
             .build()
-
-        val companion = TypeSpec.companionObjectBuilder()
-            .addModifiers(KModifier.PUBLIC)
-            .addFunction(provideChildFactoryFun)
-            .addFunction(provideConfigBindingFun)
-            .build()
-
-        val bindingInterface = TypeSpec.interfaceBuilder(data.bindingClassName)
-            .addModifiers(KModifier.PUBLIC)
-            .addAnnotation(contributesTo(data.parentScope))
-            .addType(companion)
-            .build()
-
-        return FileSpec.builder(data.bindingClassName)
-            .indent(FOUR_SPACE_INDENT)
-            .addType(bindingInterface)
-            .build()
-    }
 }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/TabDestinationBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/TabDestinationBindingGenerator.kt
@@ -6,19 +6,22 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STAR
-import com.squareup.kotlinpoet.TypeSpec
 import io.github.thomaskioko.codegen.processor.data.TabData
 import io.github.thomaskioko.codegen.processor.util.ComponentContext
-import io.github.thomaskioko.codegen.processor.util.FOUR_SPACE_INDENT
 import io.github.thomaskioko.codegen.processor.util.IntoSet
 import io.github.thomaskioko.codegen.processor.util.Provides
 import io.github.thomaskioko.codegen.processor.util.TabChild
 import io.github.thomaskioko.codegen.processor.util.TabDestination
-import io.github.thomaskioko.codegen.processor.util.contributesTo
 
 internal object TabDestinationBindingGenerator {
-    fun generate(data: TabData): FileSpec {
-        val provideDestinationFun = FunSpec.builder("provide${data.baseName}TabDestination")
+    fun generate(data: TabData): FileSpec = contributingBindingFile(
+        bindingName = data.bindingClassName,
+        parentScope = data.parentScope,
+        destinationFun(data),
+    )
+
+    private fun destinationFun(data: TabData): FunSpec =
+        FunSpec.builder("provide${data.baseName}TabDestination")
             .addModifiers(KModifier.PUBLIC)
             .addAnnotation(Provides)
             .addAnnotation(IntoSet)
@@ -51,21 +54,4 @@ internal object TabDestinationBindingGenerator {
                     .build(),
             )
             .build()
-
-        val companion = TypeSpec.companionObjectBuilder()
-            .addModifiers(KModifier.PUBLIC)
-            .addFunction(provideDestinationFun)
-            .build()
-
-        val bindingInterface = TypeSpec.interfaceBuilder(data.bindingClassName)
-            .addModifiers(KModifier.PUBLIC)
-            .addAnnotation(contributesTo(data.parentScope))
-            .addType(companion)
-            .build()
-
-        return FileSpec.builder(data.bindingClassName)
-            .indent(FOUR_SPACE_INDENT)
-            .addType(bindingInterface)
-            .build()
-    }
 }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/UiBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/UiBindingGenerator.kt
@@ -1,0 +1,98 @@
+package io.github.thomaskioko.codegen.processor.codegen
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeSpec
+import io.github.thomaskioko.codegen.processor.data.UiBindingData
+import io.github.thomaskioko.codegen.processor.data.UiBindingKind
+import io.github.thomaskioko.codegen.processor.util.FOUR_SPACE_INDENT
+import io.github.thomaskioko.codegen.processor.util.IntoSet
+import io.github.thomaskioko.codegen.processor.util.Provides
+import io.github.thomaskioko.codegen.processor.util.ScreenContent
+import io.github.thomaskioko.codegen.processor.util.ScreenDestination
+import io.github.thomaskioko.codegen.processor.util.SheetContent
+import io.github.thomaskioko.codegen.processor.util.SheetDestination
+import io.github.thomaskioko.codegen.processor.util.bindingContainer
+import io.github.thomaskioko.codegen.processor.util.contributesTo
+
+/**
+ * Emits `@BindingContainer @ContributesTo(parentScope) object ${FunctionName}UiBinding` that
+ * contributes a `ScreenContent` (or `SheetContent`, depending on [UiBindingData.kind]) into the
+ * activity-scope multibinding. The `matches` predicate tests for a `ScreenDestination<*>` /
+ * `SheetDestination<*>` whose presenter is an instance of the declared type, and the `content`
+ * lambda invokes the annotated composable with the cast presenter (plus a `Modifier` for screens).
+ */
+internal object UiBindingGenerator {
+
+    fun generate(data: UiBindingData): FileSpec {
+        val shape = shapeFor(data.kind)
+
+        val provideFun = FunSpec.builder(data.provideFunName)
+            .addModifiers(KModifier.PUBLIC)
+            .addAnnotation(Provides)
+            .addAnnotation(IntoSet)
+            .returns(shape.contentType)
+            .addCode(buildProvideBody(data, shape))
+            .build()
+
+        val bindingObject = TypeSpec.objectBuilder(data.bindingClassName)
+            .addModifiers(KModifier.PUBLIC)
+            .addAnnotation(bindingContainer())
+            .addAnnotation(contributesTo(data.parentScope))
+            .addFunction(provideFun)
+            .build()
+
+        return FileSpec.builder(data.bindingClassName)
+            .indent(FOUR_SPACE_INDENT)
+            .addType(bindingObject)
+            .build()
+    }
+
+    private fun buildProvideBody(data: UiBindingData, shape: Shape): CodeBlock {
+        val builder = CodeBlock.builder()
+            .add("return %T(\n", shape.contentType)
+            .indent()
+            .add(
+                "matches = { (it as? %T<*>)?.presenter is %T },\n",
+                shape.destinationType,
+                data.presenterClass,
+            )
+        if (shape.forwardsModifier) {
+            builder.add("content = { child, modifier ->\n")
+        } else {
+            builder.add("content = { child ->\n")
+        }
+        builder.indent()
+            .add("%M(\n", data.composableFunction)
+            .indent()
+            .add(
+                "presenter = (child as %T<*>).presenter as %T,\n",
+                shape.destinationType,
+                data.presenterClass,
+            )
+        if (shape.forwardsModifier) {
+            builder.add("modifier = modifier,\n")
+        }
+        builder.unindent()
+            .add(")\n")
+            .unindent()
+            .add("},\n")
+            .unindent()
+            .add(")\n")
+        return builder.build()
+    }
+
+    private data class Shape(
+        val contentType: ClassName,
+        val destinationType: ClassName,
+        val forwardsModifier: Boolean,
+    )
+
+    private fun shapeFor(kind: UiBindingKind): Shape = when (kind) {
+        UiBindingKind.Screen -> Shape(ScreenContent, ScreenDestination, forwardsModifier = true)
+        UiBindingKind.Sheet -> Shape(SheetContent, SheetDestination, forwardsModifier = false)
+    }
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/NavData.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/NavData.kt
@@ -17,36 +17,29 @@ internal sealed interface NavData {
         get() = graphClassName.nestedClass("Factory")
 }
 
-internal data class SimpleScreenData(
+/**
+ * A root-stack screen. When [factory] is `null` the presenter is plain `@Inject` and the graph
+ * exposes it directly; when non-`null` the presenter is `@AssistedInject` with exactly one
+ * `@Assisted` constructor parameter whose name equals [routeProperty] on the route class.
+ */
+internal data class ScreenData(
     override val presenterClass: ClassName,
     override val baseName: String,
     override val packageName: String,
     override val parentScope: ClassName,
     override val scope: ClassName,
     val route: ClassName,
+    val factory: ClassName? = null,
+    val routeProperty: String? = null,
 ) : NavData {
+    val isParameterized: Boolean
+        get() = factory != null
     override val graphClassName: ClassName = ClassName(packageName, "${baseName}ScreenGraph")
     override val graphFactoryFunName: String = "create${baseName}Graph"
     override val bindingClassName: ClassName = ClassName(packageName, "${baseName}NavDestinationBinding")
-    override val graphPropertyType: ClassName = presenterClass
-    override val graphPropertyName: String = presenterAccessor(baseName)
-}
-
-internal data class ParameterizedScreenData(
-    override val presenterClass: ClassName,
-    override val baseName: String,
-    override val packageName: String,
-    override val parentScope: ClassName,
-    override val scope: ClassName,
-    val route: ClassName,
-    val factory: ClassName,
-    val routeProperty: String,
-) : NavData {
-    override val graphClassName: ClassName = ClassName(packageName, "${baseName}ScreenGraph")
-    override val graphFactoryFunName: String = "create${baseName}Graph"
-    override val bindingClassName: ClassName = ClassName(packageName, "${baseName}NavDestinationBinding")
-    override val graphPropertyType: ClassName = factory
-    override val graphPropertyName: String = factoryAccessor(baseName)
+    override val graphPropertyType: ClassName = factory ?: presenterClass
+    override val graphPropertyName: String =
+        if (isParameterized) factoryAccessor(baseName) else presenterAccessor(baseName)
 }
 
 internal data class TabData(

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/UiBindingData.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/UiBindingData.kt
@@ -1,0 +1,32 @@
+package io.github.thomaskioko.codegen.processor.data
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.MemberName
+
+/**
+ * Distinguishes the two UI renderer multibindings: a stack-side `ScreenContent` vs a modal
+ * `SheetContent`. Both share the same generated binding shape; the differing bits (content type,
+ * destination cast target, whether a `Modifier` is forwarded) are looked up from this kind at
+ * generation time.
+ */
+internal enum class UiBindingKind { Screen, Sheet }
+
+/**
+ * Source data for a `@ScreenUi` or `@SheetUi`-annotated composable.
+ *
+ * The processor reads the annotation, resolves the declared presenter type, and produces one of
+ * these per match. [UiBindingGenerator] turns it into a
+ * `@BindingContainer @ContributesTo(parentScope) object ${functionName}UiBinding` that registers
+ * a `ScreenContent` (or `SheetContent`) into the activity-scope multibinding.
+ */
+internal data class UiBindingData(
+    val kind: UiBindingKind,
+    val composableFunction: MemberName,
+    val presenterClass: ClassName,
+    val packageName: String,
+    val parentScope: ClassName,
+) {
+    val functionName: String get() = composableFunction.simpleName
+    val bindingClassName: ClassName = ClassName("$packageName.di", "${functionName}UiBinding")
+    val provideFunName: String = "provide${functionName}Content"
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/Parser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/Parser.kt
@@ -5,45 +5,32 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.squareup.kotlinpoet.ksp.toClassName
 import io.github.thomaskioko.codegen.processor.Constants
 import io.github.thomaskioko.codegen.processor.data.AssistedParamMapping
-import io.github.thomaskioko.codegen.processor.data.ParameterizedScreenData
+import io.github.thomaskioko.codegen.processor.data.ScreenData
 import io.github.thomaskioko.codegen.processor.data.SheetData
-import io.github.thomaskioko.codegen.processor.data.SimpleScreenData
 import io.github.thomaskioko.codegen.processor.data.TabData
 
-internal fun parseSimpleScreenData(
+internal fun parseScreenData(
     presenter: KSClassDeclaration,
-    @Suppress("UNUSED_PARAMETER") logger: KSPLogger,
-): SimpleScreenData? {
-    val annotation = presenter.findAnnotation(Constants.NAV_SCREEN_FQN) ?: return null
-    val route = annotation.classArgument("route")
-    val parentScope = annotation.classArgument("parentScope")
-    return SimpleScreenData(
-        presenterClass = presenter.toClassName(),
-        baseName = presenter.baseName(),
-        packageName = presenter.diPackage(),
-        parentScope = parentScope,
-        scope = route,
-        route = route,
-    )
-}
-
-internal fun parseParameterizedScreenData(
-    presenter: KSClassDeclaration,
-    nestedFactory: KSClassDeclaration,
     logger: KSPLogger,
-): ParameterizedScreenData? {
+): ScreenData? {
     val annotation = presenter.findAnnotation(Constants.NAV_SCREEN_FQN) ?: return null
     val route = annotation.classArgument("route")
     val parentScope = annotation.classArgument("parentScope")
-    val routeProperty = inferSingleRouteProperty(presenter, route.simpleName, logger) ?: return null
-    return ParameterizedScreenData(
+    val nestedFactory = presenter.findNestedAssistedFactory()
+    val (factory, routeProperty) = if (nestedFactory == null) {
+        null to null
+    } else {
+        val property = inferSingleRouteProperty(presenter, route.simpleName, logger) ?: return null
+        nestedFactory.toClassName() to property
+    }
+    return ScreenData(
         presenterClass = presenter.toClassName(),
         baseName = presenter.baseName(),
         packageName = presenter.diPackage(),
         parentScope = parentScope,
         scope = route,
         route = route,
-        factory = nestedFactory.toClassName(),
+        factory = factory,
         routeProperty = routeProperty,
     )
 }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/UiParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/UiParser.kt
@@ -1,0 +1,36 @@
+package io.github.thomaskioko.codegen.processor.parser
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.squareup.kotlinpoet.MemberName
+import io.github.thomaskioko.codegen.processor.Constants
+import io.github.thomaskioko.codegen.processor.data.UiBindingData
+import io.github.thomaskioko.codegen.processor.data.UiBindingKind
+
+internal fun parseUiBindingData(
+    function: KSFunctionDeclaration,
+    kind: UiBindingKind,
+    logger: KSPLogger,
+): UiBindingData? {
+    val (fqn, shortName) = when (kind) {
+        UiBindingKind.Screen -> Constants.SCREEN_UI_FQN to Constants.SCREEN_UI
+        UiBindingKind.Sheet -> Constants.SHEET_UI_FQN to Constants.SHEET_UI
+    }
+    val annotation = function.annotations.firstOrNull { ann ->
+        ann.annotationType.resolve().declaration.qualifiedName?.asString() == fqn
+    } ?: return null
+
+    val pkg = function.packageName.asString()
+    if (pkg.isEmpty()) {
+        logger.error("@$shortName cannot be applied to top-level functions in the default package", function)
+        return null
+    }
+
+    return UiBindingData(
+        kind = kind,
+        composableFunction = MemberName(pkg, function.simpleName.asString()),
+        presenterClass = annotation.classArgument("presenter"),
+        packageName = pkg,
+        parentScope = annotation.classArgument("parentScope"),
+    )
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/External.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/External.kt
@@ -10,6 +10,7 @@ internal val ContributesTo: ClassName = ClassName(METRO_PACKAGE, "ContributesTo"
 internal val GraphExtension: ClassName = ClassName(METRO_PACKAGE, "GraphExtension")
 internal val Provides: ClassName = ClassName(METRO_PACKAGE, "Provides")
 internal val IntoSet: ClassName = ClassName(METRO_PACKAGE, "IntoSet")
+internal val BindingContainer: ClassName = ClassName(METRO_PACKAGE, "BindingContainer")
 
 internal const val NAVIGATION_PACKAGE: String = "com.thomaskioko.tvmaniac.navigation"
 internal val NavRoute: ClassName = ClassName(NAVIGATION_PACKAGE, "NavRoute")
@@ -22,6 +23,13 @@ internal val SheetDestination: ClassName = ClassName(NAVIGATION_PACKAGE, "SheetD
 internal val SheetConfig: ClassName = ClassName(NAVIGATION_PACKAGE, "SheetConfig")
 internal val SheetChildFactory: ClassName = ClassName(NAVIGATION_PACKAGE, "SheetChildFactory")
 internal val SheetConfigBinding: ClassName = ClassName(NAVIGATION_PACKAGE, "SheetConfigBinding")
+
+internal const val NAVIGATION_UI_PACKAGE: String = "com.thomaskioko.tvmaniac.navigation.ui"
+internal val ScreenContent: ClassName = ClassName(NAVIGATION_UI_PACKAGE, "ScreenContent")
+internal val SheetContent: ClassName = ClassName(NAVIGATION_UI_PACKAGE, "SheetContent")
+
+internal const val COMPOSE_UI_PACKAGE: String = "androidx.compose.ui"
+internal val Modifier: ClassName = ClassName(COMPOSE_UI_PACKAGE, "Modifier")
 
 internal const val HOME_NAV_PACKAGE: String = "com.thomaskioko.tvmaniac.home.nav"
 internal val TabDestination: ClassName = ClassName(HOME_NAV_PACKAGE, "TabDestination")

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/KotlinPoet.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/KotlinPoet.kt
@@ -13,6 +13,9 @@ internal fun contributesTo(scope: ClassName): AnnotationSpec =
         .addMember("%T::class", scope)
         .build()
 
+internal fun bindingContainer(): AnnotationSpec =
+    AnnotationSpec.builder(BindingContainer).build()
+
 internal fun graphExtension(scope: ClassName): AnnotationSpec =
     AnnotationSpec.builder(GraphExtension)
         .addMember("%T::class", scope)

--- a/gradle/publishing.properties
+++ b/gradle/publishing.properties
@@ -2,7 +2,7 @@
 # Composite-specific overrides (POM_NAME, POM_DESCRIPTION) stay in each
 # composite's own gradle.properties.
 GROUP=io.github.thomaskioko.gradle.plugins
-VERSION_NAME=0.7.1
+VERSION_NAME=0.7.2
 INCEPTION_YEAR=2025
 
 POM_REPO_NAME=app-gradle-plugins

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
@@ -57,6 +57,11 @@ public abstract class BaseExtension(private val project: Project) : ExtensionAwa
     }
 
     public fun useCodegen() {
+        // Codegen relies on Metro's annotation processing, so we can apply the Metro plugin and configure it first
+        if(!project.plugins.hasPlugin("dev.zacsweers.metro")) {
+            useMetro()
+        }
+
         project.configureProcessing()
         project.addImplementationDependency(project.getDependency("codegen-annotations"))
         project.addKspDependencyForAllTargets(project.getDependency("codegen-processor"))


### PR DESCRIPTION
## Description
This PR introduces two new annotations (`@ScreenUi`, `@SheetUi`) that generate Metro `@BindingContainer` objects wiring Android Compose renderers into the navigation graph as `ScreenContent` / `SheetContent` multibinding contributions. It also folds `SimpleScreenData` and `ParameterizedScreenData` into a single `ScreenData`.

## Plugin DSL Changes
- `useCodegen()` no longer requires consumers to call `useMetro()`. It applies Metro

