### PR TITLE
Implement Navigation Codegen for AppRoot and Tabs with Lint Rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
 
       - name: Check code formatting
-        run: ./gradlew spotlessCheck
+        run: ./gradlew spotlessCheckAll
 
       - name: Check dependency health
         run: ./gradlew buildHealthAll --no-configuration-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 Change Log
 ==========
 
+## 0.7.7 *(2026-05-10)*
+
+### Navigation
+
+Two new annotations cover the application's root host. The pair eliminates the manual `@BindingContainer` that consumers used to write for the root presenter and the multi-argument call site every activity used to make to render the root composable.
+
+- `@AppRoot` targets an `@AssistedInject` presenter implementation. The processor reads the nested `@AssistedFactory`, infers the bound interface from the implementation's supertypes, and emits a `<InterfaceName>BindingContainer` that contributes `@Provides @SingleIn(parentScope)` for the bound interface. Consumers replace their hand-written root binding container with one annotation.
+- `@AppRootUi` targets the host `@Composable` function. The processor reads the function's non-modifier parameters and emits an `AppRootProvider` interface plus a `@Composable AppRootProvider.AppRootContent(modifier)` extension. Consumers make their activity-scope `@DependencyGraph` extend the generated `AppRootProvider`, and the activity invokes `graph.AppRootContent()` instead of forwarding each dependency by hand.
+
+The codegen now publishes `@SingleIn`, `@Composable`, and `Modifier` in addition to the previously-published Metro and Decompose constants. See [annotations.md](codegen/docs/annotations.md), [examples.md](codegen/docs/examples.md) sections 7 and 8, and [architecture/consumer-contract.md](codegen/docs/architecture/consumer-contract.md) for the full surface.
+
+### Lint rules
+
+Two new ktlint rules enforce that the codegen annotations above are actually applied. Forgetting either annotation now fails the build at lint time rather than slipping through to runtime.
+
+- `tvmaniac:presenter-needs-codegen-annotation` flags any top-level class whose name ends with `Presenter` and is annotated with `@Inject` or `@AssistedInject` but is missing both `@NavDestination` and `@AppRoot`. Classes carrying a `@Contributes...` Metro annotation are exempt; child presenters routed through a manual `@GraphExtension` opt out via the new `ktlint_tvmaniac_unrouted_presenters` editorconfig property.
+- `tvmaniac:compose-screen-needs-codegen-annotation` flags any top-level `@Composable` function with a `presenter` or `rootPresenter` parameter that is missing `@ScreenUi`, `@SheetUi`, and `@AppRootUi`. Tab-root screens dispatched manually inside a parent host opt out via the new `ktlint_tvmaniac_unrouted_screens` editorconfig property.
+
+
+### KSP
+
+- Register the `kspCommonMainKotlinMetadata` output (`build/generated/ksp/metadata/commonMain/kotlin`) as a `commonMain` Kotlin source directory for KMP projects, and wire every `KotlinCompilationTask` and per-target `ksp*` task to depend on it. Resolves IDE `Unresolved reference` warnings for KSP-generated symbols (Metro `@GraphExtension`, navigation codegen) referenced from `commonMain`.
+- `useCodegen()` now registers the navigation codegen processor only on `kspCommonMainMetadata` for KMP projects (via the new `addKspDependencyForCommonMain` helper). Combined with the metadata srcDir registration above, this avoids duplicate generation that would otherwise occur when per-target ksp tasks reprocessed commonMain sources.
+
 ## 0.7.6 *(2026-05-09)*
 
 ### Navigation

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,3 +23,12 @@ tasks.register("buildHealthAll") {
     dependsOn(gradle.includedBuild("lint-rules").task(":buildHealth"))
     dependsOn(gradle.includedBuild("codegen").task(":buildHealth"))
 }
+
+tasks.register("spotlessApplyAll") {
+    group = "formatting"
+    description = "Run spotlessApply across root + plugins + lint-rules + codegen composite builds."
+    dependsOn("spotlessApply")
+    dependsOn(gradle.includedBuild("plugins").task(":spotlessApply"))
+    dependsOn(gradle.includedBuild("lint-rules").task(":spotlessApply"))
+    dependsOn(gradle.includedBuild("codegen").task(":spotlessApply"))
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,3 +32,12 @@ tasks.register("spotlessApplyAll") {
     dependsOn(gradle.includedBuild("lint-rules").task(":spotlessApply"))
     dependsOn(gradle.includedBuild("codegen").task(":spotlessApply"))
 }
+
+tasks.register("spotlessCheckAll") {
+    group = "verification"
+    description = "Run spotlessCheck across root + plugins + lint-rules + codegen composite builds."
+    dependsOn("spotlessCheck")
+    dependsOn(gradle.includedBuild("plugins").task(":spotlessCheck"))
+    dependsOn(gradle.includedBuild("lint-rules").task(":spotlessCheck"))
+    dependsOn(gradle.includedBuild("codegen").task(":spotlessCheck"))
+}

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -8,9 +8,12 @@ Decompose's `ChildStack`, `ChildSlot`, and `ComponentContext` primitives directl
 
 One annotation (`@NavDestination`) covers stack screens, modal overlays, and bottom navigation tab
 roots. Two more (`@ScreenUi`, `@SheetUi`) cover the renderer bindings that join Android composables
-to the navigation host. The processor emits the boilerplate that each destination would otherwise
-need: a Metro `@GraphExtension` graph, a `NavDestination` binding for the Decompose host, and a UI
-renderer binding for the Android side.
+to the navigation host. Two more (`@AppRoot`, `@AppRootUi`) cover the application's root presenter
+and the host composable that wraps every other screen. The processor emits the boilerplate that
+each destination would otherwise need: a Metro `@GraphExtension` graph, a `NavDestination` binding
+for the Decompose host, a UI renderer binding for the Android side, the activity-scope binding
+container for the root presenter, and the provider interface plus extension that lets the activity
+render the root with one call.
 
 ## What you need
 

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/AppRoot.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/AppRoot.kt
@@ -1,0 +1,61 @@
+package io.github.thomaskioko.codegen.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Marks an `@AssistedInject` presenter implementation as the application's root host, so the
+ * codegen processor can wire its bound interface into [parentScope] at compile time.
+ *
+ * Without this annotation the consumer would have to manually write a Metro `@BindingContainer`
+ * that `@Provides @SingleIn(parentScope)` invokes the nested `@AssistedFactory` to instantiate
+ * the root presenter. With this annotation the processor emits all of that next to the
+ * implementation.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * @AppRoot(parentScope = ActivityScope::class)
+ * @AssistedInject
+ * class DefaultRootPresenter(
+ *     @Assisted componentContext: ComponentContext,
+ *     // ...
+ * ) : RootPresenter, ComponentContext by componentContext {
+ *
+ *     @AssistedFactory
+ *     fun interface Factory {
+ *         fun create(componentContext: ComponentContext): DefaultRootPresenter
+ *     }
+ * }
+ * ```
+ *
+ * The processor emits one file (`<InterfaceName>BindingContainer.kt`) into the implementation's
+ * `<package>.di` package. The file contains a `@BindingContainer @ContributesTo(parentScope)
+ * object` whose `@Provides @SingleIn(parentScope)` function takes a `ComponentContext` and the
+ * nested `Factory`, and returns the bound interface.
+ *
+ * ## Bound interface inference
+ *
+ * The processor reads the implementation's supertypes and picks the first non-marker interface as
+ * the bound type. Decompose's `ComponentContext` (commonly used as a delegate via
+ * `ComponentContext by componentContext`) is filtered out. Implementations that extend more than
+ * one non-marker interface are rejected at compile time.
+ *
+ * ## Validation
+ *
+ * The processor reports a compile error if any of the following hold:
+ *
+ * - The annotated symbol is not a class.
+ * - The class does not carry `@AssistedInject`.
+ * - The class does not declare a nested `@AssistedFactory` interface.
+ * - The nested factory does not have exactly one function whose single parameter is a
+ *   `ComponentContext` and whose return type equals the implementation type.
+ * - The class extends zero or more than one non-marker interface.
+ *
+ * @property parentScope The dependency injection scope hosting the generated binding (typically
+ *   `ActivityScope::class` in the consumer project).
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class AppRoot(
+    val parentScope: KClass<*>,
+)

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/AppRootUi.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/AppRootUi.kt
@@ -1,0 +1,69 @@
+package io.github.thomaskioko.codegen.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Marks a `@Composable` function as the application's root host composable, so the codegen
+ * processor can emit a provider interface and an extension that the activity's dependency graph
+ * implements.
+ *
+ * Without this annotation the activity has to invoke the root composable with one argument for
+ * each shared dependency the composable accepts. With this annotation the processor reads the
+ * composable's parameter list, emits an `AppRootProvider` interface declaring one `val` for each
+ * non-modifier parameter, and emits a `@Composable AppRootProvider.AppRootContent(modifier)`
+ * extension that invokes the annotated composable using the receiver's properties. The activity
+ * call site collapses from one argument per dependency to one extension call.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * @Composable
+ * @AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)
+ * fun RootScreen(
+ *     rootPresenter: RootPresenter,
+ *     screenContents: Set<ScreenContent>,
+ *     sheetContents: Set<SheetContent>,
+ *     modifier: Modifier = Modifier,
+ * ) {
+ *     // ... compose UI here
+ * }
+ * ```
+ *
+ * The processor emits one file (`<FunctionName>AppRootUiBinding.kt`) into the same module's
+ * `<package>.di` sub package. The file contains the `AppRootProvider` interface and the
+ * `AppRootContent` extension. The consumer makes its activity-scope `@DependencyGraph` extend
+ * `AppRootProvider`, then calls `graph.AppRootContent()` from the activity.
+ *
+ * ## Composable signature requirement
+ *
+ * The annotated function must:
+ *
+ * - Be `@Composable`.
+ * - Declare at least one non-modifier parameter.
+ * - Declare its first non-modifier parameter as the [presenter] type.
+ *
+ * The processor reads the parameter list in order and skips any parameter named `modifier` whose
+ * type is `androidx.compose.ui.Modifier`. Every other parameter becomes a property on the
+ * generated `AppRootProvider` interface.
+ *
+ * ## Validation
+ *
+ * The processor reports a compile error if any of the following hold:
+ *
+ * - The annotated symbol is not a function.
+ * - The function lives in the default (empty) package.
+ * - The function has no non-modifier parameters.
+ * - The first non-modifier parameter type does not equal [presenter].
+ * - More than one `@AppRootUi` is declared in the same compilation round.
+ *
+ * @property presenter The root presenter type. Must equal the first non-modifier parameter type
+ *   on the annotated composable. Used for compile-time validation.
+ * @property parentScope The dependency injection scope hosting the generated artifacts (typically
+ *   `ActivityScope::class` in the consumer project).
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class AppRootUi(
+    val presenter: KClass<*>,
+    val parentScope: KClass<*>,
+)

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/ChildPresenter.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/ChildPresenter.kt
@@ -1,0 +1,84 @@
+package io.github.thomaskioko.codegen.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Marks a presenter class as a child presenter exposed through a graph extension scoped to its
+ * parent host (typically a tab pager presenter).
+ *
+ * Without this annotation a parent presenter that exposes child presenters has to hand-write the
+ * `@GraphExtension` interface with each child as a property, plus the nested factory contributing
+ * to the parent's scope. With this annotation the processor emits one `@GraphExtension` for each
+ * annotated child, named `<Presenter>ChildGraph`, that the parent presenter can consume as a
+ * factory.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * @Inject
+ * @ChildPresenter(
+ *     scope = ProgressChildScope::class,
+ *     parentScope = ProgressRoot::class,
+ * )
+ * public class UpNextPresenter(
+ *     componentContext: ComponentContext,
+ *     // ... deps
+ * ) : ComponentContext by componentContext
+ * ```
+ *
+ * The processor emits one file (`UpNextChildGraph.kt`) into the presenter's `<package>.di`
+ * sub-package:
+ *
+ * ```kotlin
+ * @GraphExtension(ProgressChildScope::class)
+ * public interface UpNextChildGraph {
+ *     public val upNextPresenter: UpNextPresenter
+ *
+ *     @ContributesTo(ProgressRoot::class)
+ *     @GraphExtension.Factory
+ *     public interface Factory {
+ *         public fun createUpNextGraph(@Provides componentContext: ComponentContext): UpNextChildGraph
+ *     }
+ * }
+ * ```
+ *
+ * The parent presenter consumes one factory for each child:
+ *
+ * ```kotlin
+ * @Inject
+ * public class ProgressPresenter(
+ *     componentContext: ComponentContext,
+ *     upNextGraphFactory: UpNextChildGraph.Factory,
+ *     calendarGraphFactory: CalendarChildGraph.Factory,
+ * ) : ComponentContext by componentContext {
+ *     public val upNextPresenter: UpNextPresenter =
+ *         upNextGraphFactory.createUpNextGraph(childContext(key = "UpNext")).upNextPresenter
+ *     public val calendarPresenter: CalendarPresenter =
+ *         calendarGraphFactory.createCalendarGraph(childContext(key = "Calendar")).calendarPresenter
+ * }
+ * ```
+ *
+ * ## When to use it
+ *
+ * Use `@ChildPresenter` when a presenter is created and owned by a parent presenter rather than
+ * navigated to through a route. Tab-internal pagers, expanding-card sub-screens, and similar
+ * sub-components fit this pattern. Routed destinations should use `@NavDestination` instead.
+ *
+ * ## Validation
+ *
+ * The processor reports a compile error if any of the following hold:
+ *
+ * - The annotated symbol is not a class.
+ * - The presenter is parameterized but does not have exactly one `@Assisted` constructor parameter.
+ *
+ * @property scope The graph scope. Used as the marker on the generated `@GraphExtension`.
+ *   Multiple `@ChildPresenter` classes may share a scope; each gets its own graph extension.
+ * @property parentScope The parent dependency injection scope hosting the generated factory
+ *   (typically the route class of the parent host, for example `ProgressRoot::class`).
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class ChildPresenter(
+    val scope: KClass<*>,
+    val parentScope: KClass<*>,
+)

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/TabUi.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/TabUi.kt
@@ -1,0 +1,60 @@
+package io.github.thomaskioko.codegen.annotations
+
+import kotlin.reflect.KClass
+
+/**
+ * Marks a `@Composable` function as the Android renderer for a tab-root presenter.
+ *
+ * Tab roots are wrapped in `TabChild<*>` rather than `ScreenDestination<*>` (per the codegen for
+ * `@NavDestination(kind = TAB_ROOT)`), so the matcher emitted for `@ScreenUi` does not fire on
+ * them. `@TabUi` emits a parallel renderer that downcasts to `TabChild` so the same
+ * `Set<ScreenContent>` multibinding can dispatch tab roots and stack screens uniformly. The host
+ * `Children` body becomes a single `firstOrNull { it.matches(child) }` lookup rather than a
+ * hand-written `when` over tab presenter types.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * @Composable
+ * @TabUi(presenter = DiscoverShowsPresenter::class, parentScope = ActivityScope::class)
+ * fun DiscoverScreen(
+ *     presenter: DiscoverShowsPresenter,
+ *     modifier: Modifier = Modifier,
+ * ) {
+ *     // ... compose UI here
+ * }
+ * ```
+ *
+ * The processor emits one file (`DiscoverScreenUiBinding.kt`) into the same module's `<package>.di`
+ * sub-package. The file contains a `@BindingContainer @ContributesTo(parentScope) object` whose
+ * single `@Provides @IntoSet` function returns a `ScreenContent` that:
+ *
+ * - tests whether the active navigation child is a `TabChild<*>` whose `presenter` is an instance
+ *   of [presenter];
+ * - invokes the annotated composable with the cast presenter and the incoming `Modifier`.
+ *
+ * ## Composable signature requirement
+ *
+ * The annotated function must match the signature
+ * `@Composable fun <Name>(presenter: <PresenterType>, modifier: Modifier = Modifier)`. The
+ * processor does not enforce parameter names at parse time, but the generated code calls the
+ * composable with `presenter = ..., modifier = modifier`.
+ *
+ * ## When to use it
+ *
+ * Pair this with `@NavDestination(kind = TAB_ROOT)` on the matching tab presenter. The presenter
+ * lives in the shared Kotlin Multiplatform layer; the composable lives in an Android-only `ui`
+ * module. The processor emits one binding for each so they wire together at runtime through the
+ * `Set<ScreenContent>` multibinding the navigation host iterates.
+ *
+ * @property presenter The tab presenter type this screen renders. Used to build the `matches`
+ *   predicate and to cast the active child's presenter before invoking the composable.
+ * @property parentScope The parent dependency injection scope hosting the generated binding.
+ *   Typically `ActivityScope::class` in the consumer project.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class TabUi(
+    val presenter: KClass<*>,
+    val parentScope: KClass<*>,
+)

--- a/codegen/docs/annotations.md
+++ b/codegen/docs/annotations.md
@@ -2,12 +2,19 @@
 
 The annotations live in the `codegen-annotations` artifact under the package `io.github.thomaskioko.codegen.annotations`. All have `SOURCE` retention.
 
-Three annotations:
+Seven annotations:
 
 - `@NavDestination` targets presenter classes in the shared Kotlin Multiplatform layer. The processor generates a Metro `@GraphExtension` plus a navigation binding for
   each annotated presenter.
-- `@ScreenUi` and `@SheetUi` target `@Composable` functions in Android `ui` modules. The processor generates the Metro binding that contributes the composable to the
-  consumer's `Set<ScreenContent>` or `Set<SheetContent>` multibinding.
+- `@ScreenUi`, `@SheetUi`, and `@TabUi` target `@Composable` functions in Android `ui` modules. The processor generates the Metro binding that contributes the composable
+  to the consumer's `Set<ScreenContent>` or `Set<SheetContent>` multibinding. `@TabUi` is the variant for tab pager pages, where the active child is a `TabChild` rather
+  than a `ScreenDestination`.
+- `@ChildPresenter` targets a presenter class owned by another presenter rather than navigated to through a route, such as a tab pager's pages. The processor generates a
+  `<Presenter>ChildGraph` graph extension plus a factory contributing to the parent host's scope.
+- `@AppRoot` targets the application's `@AssistedInject` root presenter implementation. The processor generates the activity-scope binding container that wires the
+  nested `@AssistedFactory` to the presenter's bound interface.
+- `@AppRootUi` targets the host `@Composable` that wraps every other screen. The processor generates an `AppRootProvider` interface plus a Composable extension so the
+  activity invokes the host with one call (`graph.AppRootContent()`) instead of forwarding each dependency by hand.
 
 This reference walks through each annotation: what it marks, what the processor emits, the validation rules, and the common pitfalls. For the vocabulary used throughout
 (graph extension, multibinding, binding, slot, scope), see the glossary in [architecture/index.md](architecture/index.md#glossary).
@@ -231,6 +238,316 @@ The generated wrapper does not pass a modifier because `SheetContent.content` is
 a `ModalBottomSheet`) in the composable body, not at the call site.
 
 
+## `@TabUi`
+
+Marks a `@Composable` function as the Android renderer for one tab pager page. Parallel to `@ScreenUi`, but the predicate matches a `TabChild<*>` instead of a
+`ScreenDestination<*>`.
+
+```kotlin
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class TabUi(
+    val presenter: KClass<*>,
+    val parentScope: KClass<*>,
+)
+```
+
+### When to use `@TabUi`
+
+Pair `@TabUi` with a tab pager presenter that exposes children as `TabChild<*>` instances rather than as `ScreenDestination<*>` instances. Tv Maniac's home shell uses this
+shape: the home pager hosts a fixed set of tab pages (Discover, Library, Progress, Profile), each backed by a `TabChild`-wrapped tab presenter, and renders them through a
+`Set<ScreenContent>` multibinding.
+
+The annotation exists because `@ScreenUi`'s generated predicate (`(it as? ScreenDestination<*>)?.presenter is FooPresenter`) does not match a `TabChild<*>`. `@TabUi`
+generates the same `ScreenContent` multibinding entry but casts the child to `TabChild<*>` instead. From the host's point of view the registry is one set; the predicates
+inside the set know how to recognise their own child type.
+
+### Parameters
+
+The parameters have the same meaning as on [`@ScreenUi`](#screenui).
+
+### Minimal example
+
+```kotlin
+@Composable
+@TabUi(presenter = DiscoverShowsPresenter::class, parentScope = ActivityScope::class)
+public fun DiscoverScreen(
+    presenter: DiscoverShowsPresenter,
+    modifier: Modifier = Modifier,
+) {
+    // ... compose UI here
+}
+```
+
+### Generated artifacts
+
+For `DiscoverScreen` annotated `@TabUi(presenter = DiscoverShowsPresenter::class, parentScope = ActivityScope::class)`, the processor emits one file
+`DiscoverScreenUiBinding.kt`. The file is structurally identical to a `@ScreenUi` binding. The two differences are the cast inside the `matches` predicate
+(`(it as? TabChild<*>)?.presenter is DiscoverShowsPresenter`) and the cast inside the `content` lambda (`(child as TabChild<*>).presenter as DiscoverShowsPresenter`).
+
+### Composable signature requirement
+
+The signature requirement matches `@ScreenUi`: `@Composable fun <Name>(presenter: <PresenterType>, modifier: Modifier = Modifier)`. The generator forwards both `presenter`
+and `modifier` to the composable.
+
+
+## `@ChildPresenter`
+
+Marks a presenter class as a child presenter created and owned by a parent host presenter, such as a tab pager's pages. The processor generates a
+`<Presenter>ChildGraph` graph extension plus a factory contributing to the parent host's scope.
+
+```kotlin
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class ChildPresenter(
+    val scope: KClass<*>,
+    val parentScope: KClass<*>,
+)
+```
+
+### When to use `@ChildPresenter`
+
+Use `@ChildPresenter` when a presenter is constructed by another presenter rather than navigated to through a route. Tab pager pages, expanding-card sub-screens, and
+similar sub-components fit this pattern. Routed destinations should use `@NavDestination` instead.
+
+Without the annotation a parent presenter that exposes child presenters has to hand-write a `@GraphExtension` interface listing each child as a property plus a nested
+`@ContributesTo(parentScope) @GraphExtension.Factory` that the parent presenter consumes. With the annotation the processor emits one graph extension per annotated child,
+and the parent presenter consumes one factory per child.
+
+### Parameters
+
+The `scope` parameter is the graph scope, used as the marker on the generated `@GraphExtension`. Multiple `@ChildPresenter` classes may share a scope; each gets its own
+graph extension.
+
+The `parentScope` parameter names the parent dependency injection scope hosting the generated factory. Typically the route class of the parent host (for example
+`ProgressRoot::class`).
+
+### Minimal example
+
+```kotlin
+@Inject
+@ChildPresenter(
+    scope = ProgressChildScope::class,
+    parentScope = ProgressRoot::class,
+)
+public class UpNextPresenter(
+    componentContext: ComponentContext,
+    // ... deps
+) : ComponentContext by componentContext
+```
+
+### Generated artifacts
+
+For a presenter `com.example.feature.upnext.UpNextPresenter` annotated `@ChildPresenter(scope = ProgressChildScope::class, parentScope = ProgressRoot::class)`, the
+processor emits one file into `com.example.feature.upnext.di`:
+
+- `UpNextChildGraph.kt`: a `@GraphExtension(ProgressChildScope::class) interface UpNextChildGraph` exposing `val upNextPresenter: UpNextPresenter` and a nested
+  `@ContributesTo(ProgressRoot::class) @GraphExtension.Factory interface Factory` whose single function `createUpNextGraph(@Provides componentContext: ComponentContext)`
+  returns the graph.
+
+The factory function name is unique per presenter (`create<BaseName>Graph`) so two child graphs that contribute to the same parent scope do not collide. The base name is
+the presenter's simple name with the `Presenter` suffix stripped.
+
+### Parent presenter wiring
+
+The parent presenter takes one factory parameter for each child:
+
+```kotlin
+@Inject
+public class ProgressPresenter(
+    componentContext: ComponentContext,
+    upNextGraphFactory: UpNextChildGraph.Factory,
+    calendarGraphFactory: CalendarChildGraph.Factory,
+) : ComponentContext by componentContext {
+    public val upNextPresenter: UpNextPresenter =
+        upNextGraphFactory.createUpNextGraph(childContext(key = "UpNext")).upNextPresenter
+    public val calendarPresenter: CalendarPresenter =
+        calendarGraphFactory.createCalendarGraph(childContext(key = "Calendar")).calendarPresenter
+}
+```
+
+### Validation
+
+The processor reports a compile error if the annotated symbol is not a class.
+
+### Common pitfalls
+
+- **Forgetting `@Inject`.** `@ChildPresenter` only tells the processor which graph to generate. The presenter still needs Metro's injection annotation so Metro creates
+  instances of it.
+- **Reusing a factory function name.** Two child graphs that contribute to the same `parentScope` cannot expose factory functions with the same name. The generator
+  derives the function name from the presenter's simple name, so two child presenters in the same parent scope must have distinct simple names.
+
+
+## `@AppRoot`
+
+Marks an `@AssistedInject` presenter implementation as the application's root host. The processor emits the `@BindingContainer` that wires the nested `@AssistedFactory`
+to the bound interface at the parent scope.
+
+```kotlin
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class AppRoot(
+    val parentScope: KClass<*>,
+)
+```
+
+### When to use `@AppRoot`
+
+Use `@AppRoot` on the activity-scope root presenter implementation. The root presenter is the top-level component the activity instantiates once and hands to the host
+composable; it is not a destination in the navigation stack. Without the annotation the consumer has to hand-write a `@BindingContainer @ContributesTo(parentScope)
+object` that takes the assisted factory and a `ComponentContext` and returns the bound interface. With the annotation the processor emits that file.
+
+`@AppRoot` differs from `@NavDestination` in two ways. The root has no route, so the annotation does not take a `route` parameter. The root is bound to its public
+interface at the parent scope (typically `ActivityScope`) rather than exposed through a `@GraphExtension`, so the generated artifact is a binding container, not a graph
+plus a destination binding.
+
+### Parameters
+
+The `parentScope` parameter names the dependency injection scope hosting the generated binding. Typically `ActivityScope::class` in the consumer project.
+
+### Minimal example
+
+```kotlin
+@AppRoot(parentScope = ActivityScope::class)
+@AssistedInject
+public class DefaultRootPresenter(
+    @Assisted componentContext: ComponentContext,
+    private val navigator: Navigator,
+    // ... more deps
+) : RootPresenter, ComponentContext by componentContext {
+
+    @AssistedFactory
+    public fun interface Factory {
+        public fun create(componentContext: ComponentContext): DefaultRootPresenter
+    }
+}
+```
+
+### Generated artifacts
+
+For an implementation `com.example.app.presenter.DefaultRootPresenter` annotated `@AppRoot(parentScope = ActivityScope::class)` and implementing `RootPresenter`, the
+processor emits one file into `com.example.app.presenter.di`:
+
+- `RootPresenterBindingContainer.kt`: a `@BindingContainer @ContributesTo(parentScope) object` whose `@Provides @SingleIn(parentScope)` function takes a
+  `ComponentContext` and the nested `Factory`, and returns the bound interface (`RootPresenter` in this case). The function body invokes the factory's single function
+  with the supplied `ComponentContext`.
+
+The output replaces the hand-written binding container the consumer would otherwise have to keep in sync with the implementation's factory function name and the bound
+interface name.
+
+### Bound interface inference
+
+The processor reads the implementation's supertypes in declaration order and picks the first non-marker interface as the bound type. Decompose's `ComponentContext`
+(commonly used as a delegate via `ComponentContext by componentContext`) and Kotlin's implicit `Any` are filtered out. Implementations that extend more than one
+non-marker interface are rejected at compile time.
+
+### Validation
+
+The processor reports a compile error if any of the following hold:
+
+- The annotated symbol is not a class.
+- The class does not carry `@AssistedInject`.
+- The class does not declare a nested `@AssistedFactory` interface.
+- The nested factory does not declare exactly one function.
+- The class extends zero or more than one non-marker interface.
+
+### Common pitfalls
+
+- **Forgetting the nested factory.** `@AppRoot` requires `@AssistedInject` plus a nested `@AssistedFactory`. The factory's single function must take a `ComponentContext`
+  and return the implementation type, mirroring how the consumer would have invoked the assisted factory by hand.
+- **Multiple non-marker supertypes.** The bound type is inferred from the supertype list. If the implementation extends two interfaces (for example a presenter contract
+  and an extra interface), the processor cannot pick one and reports a compile error. Pick the bound type explicitly by removing the second interface, or merge the two
+  contracts into one.
+
+
+## `@AppRootUi`
+
+Marks the host `@Composable` function as the application's root UI. The processor generates a provider interface declaring one property for each non-modifier parameter
+on the composable plus a Composable extension that invokes the composable using the receiver's properties.
+
+```kotlin
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class AppRootUi(
+    val presenter: KClass<*>,
+    val parentScope: KClass<*>,
+)
+```
+
+### When to use `@AppRootUi`
+
+Pair `@AppRootUi` with `@AppRoot` on the matching presenter implementation. The composable is the activity's top-level Compose entry point: it receives the root
+presenter plus any multibinding sets the host needs (`Set<ScreenContent>`, `Set<SheetContent>`, and so on), and renders every screen the navigation system pushes
+underneath it.
+
+The composable is not part of the `Set<ScreenContent>` multibinding the navigation system iterates. It is the host that provides that set to its descendants. `@ScreenUi`
+does not apply for that reason. `@AppRootUi` exists so the codegen can emit a provider interface keyed off the composable's parameter list, which lets the activity
+graph extend that interface and the activity render the host with one call.
+
+### Parameters
+
+The `presenter` parameter names the root presenter type. The processor reads the composable's parameters in declaration order, skips a final `modifier: Modifier`
+parameter, and asserts that the first remaining parameter type equals `presenter`. Mismatch is a compile error.
+
+The `parentScope` parameter names the dependency injection scope hosting the generated artifacts. Typically `ActivityScope::class`.
+
+### Minimal example
+
+```kotlin
+@AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)
+@Composable
+public fun RootScreen(
+    rootPresenter: RootPresenter,
+    screenContents: Set<ScreenContent>,
+    sheetContents: Set<SheetContent>,
+    modifier: Modifier = Modifier,
+) {
+    // ... compose UI here, including the navigation host
+}
+```
+
+### Generated artifacts
+
+For a composable `com.example.app.ui.RootScreen` annotated `@AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)`, the processor emits one
+file into `com.example.app.ui.di`:
+
+- `RootScreenAppRootUiBinding.kt` contains two declarations:
+  - An `AppRootProvider` interface declaring one `val` for each non-modifier parameter on the annotated composable.
+  - A `@Composable AppRootProvider.AppRootContent(modifier: Modifier)` extension that invokes the composable using the receiver's properties.
+
+The consumer makes its activity-scope `@DependencyGraph` extend `AppRootProvider`, then calls `graph.AppRootContent()` from the activity. The activity call site
+collapses from one argument per dependency to one extension call.
+
+### Composable signature requirement
+
+The annotated function must:
+
+- Be `@Composable`.
+- Declare at least one non-modifier parameter.
+- Declare its first non-modifier parameter as the `presenter` type.
+
+The processor reads the parameter list in order and skips any parameter named `modifier` whose type is `androidx.compose.ui.Modifier`. Every other parameter becomes a
+property on the generated `AppRootProvider` interface.
+
+### Validation
+
+The processor reports a compile error if any of the following hold:
+
+- The annotated symbol is not a function.
+- The function lives in the default (empty) package.
+- The function has no non-modifier parameters.
+- The first non-modifier parameter type does not equal `presenter`.
+- More than one `@AppRootUi` is declared in the same compilation round.
+
+### Common pitfalls
+
+- **Activity graph does not extend `AppRootProvider`.** The generated extension is on `AppRootProvider`, not on the consumer's graph type directly. The consumer must
+  declare `: AppRootProvider` on its `@DependencyGraph` interface so the extension resolves at the call site.
+- **Adding a parameter without updating the graph.** Each non-modifier parameter becomes a `val` on the generated interface. If the activity graph already exposes a
+  property of the same name and type, the new field is satisfied automatically. Otherwise the consumer needs to add the property, typically as a Metro multibinding or
+  injection point.
+
+
 ## `DestinationKind`
 
 `DestinationKind` is the enum passed to `@NavDestination(kind = ...)`. It picks the role the destination plays at runtime.
@@ -269,6 +586,10 @@ Tabs additionally pull `TabChild` from `com.thomaskioko.tvmaniac.home.nav`. `Tab
 The Android UI renderer types live under `com.thomaskioko.tvmaniac.navigation.ui`. `ScreenContent` carries a `matches` predicate and a `@Composable (RootChild, Modifier)
 -> Unit` content lambda. `SheetContent` does the same for `SheetChild`. The bindings generated for `@ScreenUi` and `@SheetUi` also reference
 `androidx.compose.ui.Modifier` because the screen variant forwards a modifier into the composable.
+
+`@AppRoot` references one additional Metro primitive, `dev.zacsweers.metro.SingleIn`, used to scope the generated provider to the parent scope. `@AppRootUi` emits a
+top-level `@Composable` extension and so references `androidx.compose.runtime.Composable` and `androidx.compose.ui.Modifier` directly. These three names are also
+hardcoded constants in `util/External.kt` and have matching test stubs.
 
 The processor is opinionated about these names. Consumers other than Tv Maniac would need to adjust `util/External.kt` to match their navigation primitives. See
 [architecture/consumer-contract.md](architecture/consumer-contract.md) for why these are constants and what a fork would change.

--- a/codegen/docs/architecture/consumer-contract.md
+++ b/codegen/docs/architecture/consumer-contract.md
@@ -5,13 +5,15 @@ constants in `codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/pr
 
 ## What is hardcoded
 
-The hardcoded names fall into five groups, organised by the role each plays at runtime.
+The hardcoded names fall into six groups, organised by the role each plays at runtime.
 
 **Decompose.** `com.arkivanov.decompose.ComponentContext` is the single Decompose type the codegen references. It appears as the `@Provides` parameter on every generated
-graph factory function so every presenter on the graph can request it.
+graph factory function so every presenter on the graph can request it. `AppRootBindingGenerator` also references it as a constructor parameter on the generated
+binding container function.
 
-**Metro.** Every generated annotation references one of `dev.zacsweers.metro.{ContributesTo, GraphExtension, Provides, IntoSet, BindingContainer}`. `BindingContainer` is
-used only by `UiBindingGenerator`. The rationale is in
+**Metro.** Every generated annotation references one of `dev.zacsweers.metro.{ContributesTo, GraphExtension, Provides, IntoSet, BindingContainer, SingleIn}`.
+`BindingContainer` is used by `UiBindingGenerator` and `AppRootBindingGenerator`. `SingleIn` is used only by `AppRootBindingGenerator` to scope the generated provider
+to the parent scope. The rationale for the binding container generators is in
 [generators.md](generators.md#binding-container-object-for-ui-bindings-interface-companion-for-destination-bindings).
 
 **Consumer navigation primitives** under `com.thomaskioko.tvmaniac.navigation`:
@@ -30,7 +32,13 @@ for `SheetContent`) are part of this contract. Changing them in the consumer bre
 
 **Consumer home navigation** under `com.thomaskioko.tvmaniac.home.nav`: `TabChild`. The tab root factory lambda always wraps its produced presenter as `TabChild(...)`.
 
-**Compose.** `androidx.compose.ui.Modifier`. Only `UiBindingGenerator` references it, and only on the screen path. Overlay renderers do not forward a modifier.
+**Compose.** `androidx.compose.ui.Modifier` is referenced by `UiBindingGenerator` on the screen path (overlay renderers do not forward a modifier) and by
+`AppRootUiBindingGenerator` on the generated extension. `androidx.compose.runtime.Composable` is referenced only by `AppRootUiBindingGenerator`, which emits the
+annotation directly on the generated `AppRootContent` extension.
+
+**App root primitives.** Whatever package the consumer chose. The `@AppRoot` and `@AppRootUi` generators do not reference any consumer-specific name; the bound
+interface (`RootPresenter` in Tv Maniac), the implementation type, and the host composable all flow through from the annotated symbol via the parser. Consumers can
+rename or repackage these without touching the codegen.
 
 ## Runtime flow
 

--- a/codegen/docs/architecture/data-model.md
+++ b/codegen/docs/architecture/data-model.md
@@ -3,8 +3,10 @@
 Parsers do not feed KSP types directly to KotlinPoet generators. Every parser produces a typed intermediate value and the generators consume nothing else. This
 intermediate value lives in `codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/`.
 
-There are two top level types. Presenter side annotations (`@NavDestination`) resolve to a `NavData`. UI renderer annotations (`@ScreenUi`, `@SheetUi`) resolve to a
-`UiBindingData`. The two are independent and share no supertype because the downstream generators are structurally different.
+There are five top level types. Presenter side navigation annotations (`@NavDestination`) resolve to a `NavData`. UI renderer annotations (`@ScreenUi`, `@SheetUi`,
+`@TabUi`) resolve to a `UiBindingData`. The application root presenter annotation (`@AppRoot`) resolves to an `AppRootData`. The application root composable annotation
+(`@AppRootUi`) resolves to an `AppRootUiData`. The parent-owned child presenter annotation (`@ChildPresenter`) resolves to a `ChildPresenterData`. The five are independent
+and share no supertype because the downstream generators are structurally different.
 
 ## NavData
 
@@ -50,7 +52,7 @@ Two reasons:
 
 ## UiBindingData
 
-`UiBindingData` is a single data class plus a `UiBindingKind` enum (`Screen` or `Sheet`).
+`UiBindingData` is a single data class plus a `UiBindingKind` enum (`Screen`, `Sheet`, or `Tab`).
 
 ```kotlin
 internal data class UiBindingData(
@@ -65,9 +67,89 @@ internal data class UiBindingData(
 `composableFunction` is a KotlinPoet `MemberName` rather than a `ClassName` because the generated code calls the composable as a top level function, and `MemberName` is
 what KotlinPoet's `%M` interpolation expects. Carrying it pre formed avoids re deriving it inside the generator.
 
-The `kind` enum is what `UiBindingGenerator` switches on to pick the content type (`ScreenContent` or `SheetContent`), the destination cast target (`ScreenDestination<*>`
-or `SheetDestination<*>`), and whether the composable receives a `Modifier` parameter. The switch lives inside the generator as a private `Variant` data class; see
-[generators.md](generators.md).
+The `kind` enum is what `UiBindingGenerator` switches on to pick the content type (`ScreenContent` for `Screen` and `Tab`, `SheetContent` for `Sheet`), the destination
+cast target (`ScreenDestination<*>` for `Screen`, `SheetDestination<*>` for `Sheet`, `TabChild<*>` for `Tab`), and whether the composable receives a `Modifier` parameter
+(yes for `Screen` and `Tab`, no for `Sheet`). The switch lives inside the generator as a private `Variant` data class; see [generators.md](generators.md).
+
+## AppRootData
+
+`AppRootData` is a single data class produced by [parseAppRootData](parsers.md#approotparser).
+
+```kotlin
+internal data class AppRootData(
+    val implClassName: ClassName,
+    val interfaceClassName: ClassName,
+    val factoryClassName: ClassName,
+    val factoryFunctionName: String,
+    val parentScope: ClassName,
+    val packageName: String,
+)
+```
+
+The generator emits a `@BindingContainer @ContributesTo(parentScope) object <InterfaceName>BindingContainer` containing one `@Provides @SingleIn(parentScope)` function
+that takes a `ComponentContext` and the nested factory, and returns the bound interface. Every name the generator needs (the binding object name, the provide function
+name) is derived on the data class:
+
+```kotlin
+val bindingClassName: ClassName =
+    ClassName(packageName, "${interfaceClassName.simpleName}BindingContainer")
+val provideFunName: String =
+    "provide${interfaceClassName.simpleName}"
+```
+
+The factory's single function name (`factoryFunctionName`) is captured at parse time rather than hardcoded so a non standard factory name (`build`, `make`, etc.) works
+without generator changes.
+
+## AppRootUiData
+
+`AppRootUiData` is a single data class plus an `AppRootUiParameter` data class for each non-modifier parameter on the annotated composable.
+
+```kotlin
+internal data class AppRootUiData(
+    val composableFunction: MemberName,
+    val packageName: String,
+    val parameters: List<AppRootUiParameter>,
+    val hasModifier: Boolean,
+    val parentScope: ClassName,
+)
+
+internal data class AppRootUiParameter(
+    val name: String,
+    val type: TypeName,
+)
+```
+
+`composableFunction` is a `MemberName` for the same reason as on `UiBindingData`: the generated code calls the composable as a top level function through KotlinPoet's
+`%M` interpolation. `parameters` carries the composable's non-modifier parameters in declaration order; the generator turns each entry into a `val` on the generated
+`AppRootProvider` interface and uses the same name to call the composable inside the generated extension. `hasModifier` records whether the composable accepts a
+`modifier: Modifier` parameter, so the generator can decide whether to forward the receiver's modifier.
+
+## ChildPresenterData
+
+`ChildPresenterData` is a single data class produced by [parseChildPresenterData](parsers.md#childpresenterparser).
+
+```kotlin
+internal data class ChildPresenterData(
+    val presenterClass: ClassName,
+    val baseName: String,
+    val packageName: String,
+    val scope: ClassName,
+    val parentScope: ClassName,
+)
+```
+
+The generator emits a `@GraphExtension(scope) interface <BaseName>ChildGraph` exposing the presenter as a property and a nested
+`@ContributesTo(parentScope) @GraphExtension.Factory` interface whose single function returns the graph. The derived properties on the data class fix the naming:
+
+```kotlin
+val graphClassName: ClassName = ClassName(packageName, "${baseName}ChildGraph")
+val graphFactoryFunName: String = "create${baseName}Graph"
+val graphPropertyName: String = baseName.replaceFirstChar { it.lowercaseChar() } + "Presenter"
+```
+
+The factory function name embeds `baseName` (rather than a constant `createGraph`) so two child graphs contributing to the same parent scope do not collide. Two
+`@GraphExtension.Factory` interfaces contributed to one scope merge into Metro's parent graph, and a name clash on the factory function would surface as an
+`Incompatible return types` compile error at the activity graph.
 
 ## Why an intermediate value at all
 

--- a/codegen/docs/architecture/generators.md
+++ b/codegen/docs/architecture/generators.md
@@ -1,18 +1,24 @@
 # Generators
 
-The generator layer turns the typed intermediate values from [data-model.md](data-model.md) into KotlinPoet `FileSpec` outputs. Five generator files live under
+The generator layer turns the typed intermediate values from [data-model.md](data-model.md) into KotlinPoet `FileSpec` outputs. Eight generator files live under
 `codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/`:
 
 - `FileGenerator.kt` is the router that picks which generators run for each `NavData`.
 - `ScreenGraphGenerator.kt` emits the `@GraphExtension` interface plus its nested factory.
 - `NavDestinationBindingGenerator.kt` emits the `NavDestination` and `NavRouteBinding` companion object bindings for screens and overlays.
 - `TabDestinationBindingGenerator.kt` emits the `NavDestination.TabRoot` and `NavRootBinding` bindings for tab roots.
-- `UiBindingGenerator.kt` emits the `@BindingContainer` object that contributes `ScreenContent` or `SheetContent` for composables annotated with `@ScreenUi` or `@SheetUi`.
+- `UiBindingGenerator.kt` emits the `@BindingContainer` object that contributes `ScreenContent` or `SheetContent` for composables annotated with `@ScreenUi`, `@SheetUi`,
+  or `@TabUi`. The `kind` field on `UiBindingData` selects the variant.
+- `ChildGraphGenerator.kt` emits the `<Presenter>ChildGraph` graph extension plus its nested factory for classes annotated with `@ChildPresenter`.
+- `AppRootBindingGenerator.kt` emits the `@BindingContainer` object that wires the nested `@AssistedFactory` to the bound interface for classes annotated with `@AppRoot`.
+- `AppRootUiBindingGenerator.kt` emits the `AppRootProvider` interface plus the `@Composable AppRootProvider.AppRootContent(modifier)` extension for composables
+  annotated with `@AppRootUi`.
 
 `BindingFiles.kt` holds a shared scaffold that both destination binding generators reuse.
 
-The two paths (one for annotated presenter classes, one for annotated composable functions) converge on KotlinPoet types but never share a generator entry point.
-Presenter classes route through `FileGenerator`; composables go directly to `UiBindingGenerator`.
+The five paths (presenter `@NavDestination`, composable `@ScreenUi`/`@SheetUi`/`@TabUi`, presenter `@AppRoot`, composable `@AppRootUi`, presenter `@ChildPresenter`)
+converge on KotlinPoet types but never share a generator entry point. Presenter classes for `@NavDestination` route through `FileGenerator`; everything else is dispatched
+directly from the processor entry to its dedicated generator.
 
 ## FileGenerator routing
 
@@ -89,14 +95,38 @@ site.
 <providers> } }` scaffold that both `NavDestinationBindingGenerator` and `TabDestinationBindingGenerator` reuse. `UiBindingGenerator` does not use it because it emits a
 `@BindingContainer object` instead of an `interface + companion`. The next section explains the difference.
 
+## AppRootBindingGenerator
+
+Produces a single `@BindingContainer @ContributesTo(parentScope) object <InterfaceName>BindingContainer` whose only function is annotated `@Provides @SingleIn(parentScope)`,
+takes a `ComponentContext` and the nested `@AssistedFactory`, and returns the bound interface. The function body is one expression: `return factory.<factoryFunctionName>(componentContext)`.
+The factory function name comes from `AppRootData.factoryFunctionName`, captured at parse time so a non-default name (`build`, `make`, etc.) works without generator
+changes.
+
+The output is intentionally byte-equivalent to the hand-written binding container the consumer would otherwise have to keep in sync. The reasoning: the generator
+replaces a manually written file. Diffing the generated output against a checked-in golden lets contributors verify the equivalence at every change.
+
+## AppRootUiBindingGenerator
+
+Produces one `FileSpec` containing two declarations:
+
+- An `AppRootProvider` interface with one `val` for each non-modifier parameter on the annotated composable. The properties are declared in declaration order; their
+  names and types are read off `AppRootUiData.parameters`.
+- A `@Composable AppRootProvider.AppRootContent(modifier: Modifier = Modifier)` extension that invokes the composable through `MemberName`, passing each parameter from
+  the matching property on the receiver. When `AppRootUiData.hasModifier` is `true`, the extension forwards `modifier`; otherwise the parameter is omitted from the
+  invocation.
+
+The extension lives on the generated provider interface, not on a specific consumer graph type. Consumers make their `@DependencyGraph` extend `AppRootProvider`, which
+keeps the codegen independent of the consumer's graph type and avoids a circular module dependency between `features/root/ui` (where the annotated composable lives)
+and the consumer's `:app` module (where the graph lives).
+
 ## Two output structure decisions
 
 Two non obvious choices in the output that are worth understanding before editing a generator.
 
 ### `@BindingContainer object` for UI bindings, `interface + companion` for destination bindings
 
-The bindings the codegen emits for `@NavDestination` use Metro's `interface + companion object` structure. The bindings the codegen emits for `@ScreenUi` and `@SheetUi`
-use Metro's `@BindingContainer object` structure instead. The reason is a Metro detail.
+The bindings the codegen emits for `@NavDestination` use Metro's `interface + companion object` structure. The bindings the codegen emits for `@ScreenUi`, `@SheetUi`, and
+`@TabUi` use Metro's `@BindingContainer object` structure instead. The reason is a Metro detail.
 
 `@Provides @IntoSet` declarations inside an `interface + companion object` only become contributions when Metro's `generateContributionProviders` flag is enabled, and
 that flag is disabled in the consumer scaffold. The presenter side bindings work with the interface form because the consumer's Kotlin Multiplatform source set picks them

--- a/codegen/docs/architecture/index.md
+++ b/codegen/docs/architecture/index.md
@@ -17,8 +17,9 @@ The processor turns one annotated symbol into one or two Kotlin source files on 
 
 Every architecture page draws from this single vocabulary. New terms introduced on a specific page are defined inline on that page.
 
-- **variant**. The structural form of a generated artifact. Five variants exist: a presenter with no runtime parameters, a parameterized presenter, a tab root, a screen
-  renderer, and an overlay renderer. Each variant has its own golden directory under `codegen/processor-test/src/test/resources/golden/`.
+- **variant**. The structural form of a generated artifact. Nine variants exist: a presenter with no runtime parameters, a parameterized presenter, a tab root, a screen
+  renderer, an overlay renderer, a tab pager renderer, a parent-owned child presenter graph, the application's root presenter binding, and the application's root host
+  composable. Each variant has its own golden directory under `codegen/processor-test/src/test/resources/golden/`.
 - **binding**. A Kotlin interface or object that contributes one or more entries to a Metro multibinding. The processor emits one binding per annotated destination and
   one per annotated UI renderer.
 - **multibinding**. A Metro pattern where many `@Provides` contributions are collected into a single `Set<T>` that downstream code can request as a whole. The codegen
@@ -43,8 +44,8 @@ Every architecture page draws from this single vocabulary. New terms introduced 
 
 The `codegen/` directory contains three Gradle sub modules that the architecture pages reference repeatedly.
 
-- `annotations/` is a Kotlin Multiplatform library that defines `@NavDestination`, `@ScreenUi`, and `@SheetUi`. It carries no logic; it is just the surface that consumers
-  depend on.
+- `annotations/` is a Kotlin Multiplatform library that defines `@NavDestination`, `@ScreenUi`, `@SheetUi`, `@TabUi`, `@ChildPresenter`, `@AppRoot`, and `@AppRootUi`. It
+  carries no logic; it is just the surface that consumers depend on.
 - `processor/` is a JVM library that hosts the KSP `SymbolProcessor` plus the KotlinPoet generators. This is where every architecture page after [pipeline.md](pipeline.md) lives.
 - `processor-test/` is a JVM test module that uses `dev.zacsweers.kctfork` to compile annotated input and assert the output against goldens under
   `src/test/resources/golden/`. Covered in [testing.md](testing.md).

--- a/codegen/docs/architecture/parsers.md
+++ b/codegen/docs/architecture/parsers.md
@@ -1,12 +1,15 @@
 # Parsers
 
-The parser layer maps KSP symbols into the typed intermediate values described in [data-model.md](data-model.md). Two parser files live under
+The parser layer maps KSP symbols into the typed intermediate values described in [data-model.md](data-model.md). Five parser files live under
 `codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/`:
 
 - `NavDestinationParser.kt` covers the `@NavDestination` path for all three destination kinds.
-- `UiParser.kt` covers `@ScreenUi` and `@SheetUi`.
+- `UiParser.kt` covers `@ScreenUi`, `@SheetUi`, and `@TabUi`.
+- `ChildPresenterParser.kt` covers `@ChildPresenter` on parent-owned child presenters.
+- `AppRootParser.kt` covers `@AppRoot` on the root presenter implementation.
+- `AppRootUiParser.kt` covers `@AppRootUi` on the host composable.
 
-Both parsers share `AnnotationArguments.kt`, a small set of KSP extension helpers.
+All five parsers share `AnnotationArguments.kt`, a small set of KSP extension helpers.
 
 ## Annotation argument helpers
 
@@ -55,12 +58,49 @@ later restored, which defeats the polymorphic save and restore the rest of the c
 
 ## UiParser
 
-`parseUiBindingData` is shared by `@ScreenUi` and `@SheetUi`. The caller passes a `UiBindingKind` (`Screen` or `Sheet`) and the parser configures itself accordingly. It
-rejects functions in the default package (the generated binding needs a non empty package to land in), records the function as a `MemberName`, reads `presenter` and
-`parentScope` as `ClassName` instances, and returns a `UiBindingData`.
+`parseUiBindingData` is shared by `@ScreenUi`, `@SheetUi`, and `@TabUi`. The caller passes a `UiBindingKind` (`Screen`, `Sheet`, or `Tab`) and the parser configures itself
+accordingly. It rejects functions in the default package (the generated binding needs a non empty package to land in), records the function as a `MemberName`, reads
+`presenter` and `parentScope` as `ClassName` instances, and returns a `UiBindingData`.
 
-There is no `@AssistedInject` detection branch on the UI side. The generated binding has the same structure for both `@ScreenUi` and `@SheetUi`. The fields that vary by
-kind (the content type, the destination cast target, whether to forward `Modifier`) are picked at generation time, not at parse time. See [generators.md](generators.md).
+There is no `@AssistedInject` detection branch on the UI side. The generated binding has the same structure for all three kinds. The fields that vary by kind (the content
+type, the destination cast target, whether to forward `Modifier`) are picked at generation time, not at parse time. See [generators.md](generators.md).
+
+## ChildPresenterParser
+
+`parseChildPresenterData` reads `@ChildPresenter`, captures the annotated class as a `ClassName`, derives the base name (the simple name with the `Presenter` suffix
+stripped), and reads `scope` and `parentScope` as `ClassName` instances. It returns a `ChildPresenterData` whose derived properties (`graphClassName`,
+`graphFactoryFunName`, `graphPropertyName`) the generator consumes verbatim.
+
+The parser is intentionally minimal. There is no `@AssistedInject` detection branch and no nested factory walk; child presenters always use plain `@Inject` because the
+parent host instantiates them through `Decompose.childContext(key)` rather than from a route payload. The processor entry checks that the annotated symbol is a class
+before delegating; the parser itself does not need to re-validate the symbol kind.
+
+## AppRootParser
+
+`parseAppRootData` reads `@AppRoot`, validates the annotated class, and returns an `AppRootData`. Validation runs in three steps:
+
+1. The class must carry `@AssistedInject`. Missing the annotation is a compile error pinned to the class declaration. `@AppRoot` does not generate Metro injection, only
+   the binding container that calls the assisted factory; the factory itself still needs `@AssistedInject` for Metro to instantiate it.
+2. The class must declare a nested `@AssistedFactory` interface with exactly one function. The function's name (typically `create`) is captured for use in the generated
+   provider body.
+3. The class must extend exactly one non-marker interface. `inferBoundInterface` walks the resolved supertypes, skips `kotlin.Any` and `com.arkivanov.decompose.ComponentContext`,
+   and asserts that exactly one candidate remains. Zero is a compile error (the consumer forgot to declare the bound interface). More than one is a compile error (the
+   processor cannot pick one).
+
+The bound interface is what the generated provider returns. The processor uses the inferred name to derive the binding object name (`<InterfaceName>BindingContainer`)
+and the provide function name (`provide<InterfaceName>`). These names are part of the contract the consumer commits to; goldens lock them down.
+
+## AppRootUiParser
+
+`parseAppRootUiData` reads `@AppRootUi`, validates the annotated function, and returns an `AppRootUiData`. The parser walks the function's parameter list in declaration
+order, looks for a final parameter named `modifier` whose type is `androidx.compose.ui.Modifier`, and treats every other parameter as a graph dependency. The graph
+dependencies become properties on the generated `AppRootProvider` interface; the modifier (when present) is forwarded by the generated extension.
+
+The first non-modifier parameter type must equal the annotation's `presenter` argument. Mismatch is a compile error: it indicates that either the annotation or the
+composable was changed without updating the other. The check is shallow (compares canonical names as strings) but catches the common case of a presenter rename.
+
+Tabs through the same single-`@AppRootUi`-per-round restriction as the navigator-side annotations, but enforced at the processor entry rather than at parse time. The
+duplicate check lives in `processAppRootUi` because it tracks state across symbols within one round; the parser stays a pure function.
 
 ## Error reporting
 

--- a/codegen/docs/architecture/pipeline.md
+++ b/codegen/docs/architecture/pipeline.md
@@ -8,7 +8,7 @@ KSP loads it through `NavigationCodegenProcessorProvider` and calls `process(res
 A KSP round is one pass of the processor over the current source set. KSP can run multiple rounds when other processors produce new symbols, but this codegen never
 produces input for itself, so it runs once per build and returns an empty list of deferred symbols.
 
-Each call walks three annotation queries in order. The fully qualified names are kept as `const val` declarations in `Constants.kt` so the processor and its tests share a
+Each call walks seven annotation queries in order. The fully qualified names are kept as `const val` declarations in `Constants.kt` so the processor and its tests share a
 single source of truth.
 
 ```kotlin
@@ -18,22 +18,43 @@ override fun process(resolver: Resolver): List<KSAnnotated> {
     }
     processUiBinding(resolver, Constants.SCREEN_UI_FQN, Constants.SCREEN_UI, UiBindingKind.Screen)
     processUiBinding(resolver, Constants.SHEET_UI_FQN, Constants.SHEET_UI, UiBindingKind.Sheet)
+    processUiBinding(resolver, Constants.TAB_UI_FQN, Constants.TAB_UI, UiBindingKind.Tab)
+    processAppRoot(resolver)
+    processAppRootUi(resolver)
+    processChildPresenter(resolver)
     return emptyList()
 }
 ```
 
-`processAnnotation` and `processUiBinding` are the two private helpers that cover the two kinds of annotated symbol the processor recognises. Both follow the same steps:
-read the matching symbols from KSP, type check each one, pass it to a parser, route the parser's result to a generator. They differ only in the symbol kind they accept.
+Five private helpers cover the kinds of annotated symbol the processor recognises. `processAnnotation` and `processUiBinding` cover the navigation annotations; three
+named helpers (`processAppRoot`, `processAppRootUi`, `processChildPresenter`) cover the standalone class and function targets. All five follow the same steps: read the
+matching symbols from KSP, type check each one, pass it to a parser, route the parser's result to a generator. They differ only in the symbol kind they accept and the
+data type they produce.
 
-## Two paths
+## Five paths
 
-`processAnnotation` is the path for class targets. Currently only `@NavDestination` uses it. KSP returns every class declaration carrying the annotation; the helper hands
-each to the parser, which returns a `NavData?`. A null return means the parser already logged a compile error and the helper skips the symbol. A non null return goes to
-`FileGenerator.generate(data)`, which produces the graph file and the binding file. `writeFiles` writes them through KSP's `CodeGenerator`.
+`processAnnotation` is the path for class targets that produce a `NavData`. Currently only `@NavDestination` uses it. KSP returns every class declaration carrying the
+annotation; the helper hands each to the parser, which returns a `NavData?`. A null return means the parser already logged a compile error and the helper skips the
+symbol. A non null return goes to `FileGenerator.generate(data)`, which produces the graph file and the binding file. `writeFiles` writes them through KSP's
+`CodeGenerator`.
 
-`processUiBinding` is the path for function targets. Both `@ScreenUi` and `@SheetUi` use it. KSP returns every function declaration carrying the annotation; the helper
-hands each to `parseUiBindingData`, which returns a `UiBindingData?`. A non null result goes directly to `UiBindingGenerator.generate(data)` (there is no router wrapper
-because each annotation produces exactly one file).
+`processUiBinding` is the path for function targets that produce a `UiBindingData`. `@ScreenUi`, `@SheetUi`, and `@TabUi` all use it, distinguished by a `UiBindingKind`
+enum value the caller passes in. KSP returns every function declaration carrying the annotation; the helper hands each to `parseUiBindingData`, which returns a
+`UiBindingData?`. A non null result goes directly to `UiBindingGenerator.generate(data)` (there is no router wrapper because each annotation produces exactly one file).
+
+`processAppRoot` is the path for `@AppRoot`. KSP returns every class declaration carrying the annotation; the helper hands each to `parseAppRootData`, which returns an
+`AppRootData?`. A non null result goes directly to `AppRootBindingGenerator.generate(data)`. The data type is independent of `NavData` because the generated binding
+container has a different structure than a destination binding (it is a `@BindingContainer object` that exposes the bound interface, not an interface plus companion
+contributing into a multibinding).
+
+`processAppRootUi` is the path for `@AppRootUi`. KSP returns every function declaration carrying the annotation; the helper rejects more than one annotated function per
+round and reports a compile error pointing at the duplicate. A single annotation goes to `parseAppRootUiData`, which returns an `AppRootUiData?`. A non null result goes
+directly to `AppRootUiBindingGenerator.generate(data)`. The data type is independent of `UiBindingData` because the generated artifact is a provider interface plus an
+extension, not a `ScreenContent` or `SheetContent` multibinding entry.
+
+`processChildPresenter` is the path for `@ChildPresenter`. KSP returns every class declaration carrying the annotation; the helper hands each to
+`parseChildPresenterData`, which returns a `ChildPresenterData?`. A non null result goes directly to `ChildGraphGenerator.generate(data)`. The data type is independent of
+`NavData` because the generated artifact is a graph extension exposing a single presenter, with no destination binding entry alongside it.
 
 ## File writing
 

--- a/codegen/docs/architecture/testing.md
+++ b/codegen/docs/architecture/testing.md
@@ -33,9 +33,12 @@ the actual `@NavDestination` symbol, not a stub.
 `TestStubs.kt` carries minimal source level fakes of the consumer project types the generator references. Each stub is a `Pair<String, String>` of file name and source
 text. Three lists group them by what each set of tests needs.
 
-- `baseStubs` covers the common set: Decompose `ComponentContext`, `ActivityScope`, the navigation primitives, Metro annotations, `kotlinx.serialization`. Every test pulls these.
-- `tabStubs` adds the `TabChild` type from the home navigation package (`com.thomaskioko.tvmaniac.home.nav`). Tab root tests pull these.
-- `uiStubs` adds the Compose annotations and the navigation UI primitives (`ScreenContent`, `SheetContent`). `@ScreenUi` and `@SheetUi` tests pull these.
+- `baseStubs` covers the common set: Decompose `ComponentContext`, `ActivityScope`, the navigation primitives, Metro annotations (including `@SingleIn`),
+  `kotlinx.serialization`. Every test pulls these.
+- `tabStubs` adds the `TabChild` type from the home navigation package (`com.thomaskioko.tvmaniac.home.nav`). Tab root tests and `@TabUi` tests pull these.
+- `uiStubs` adds the Compose UI annotations and the navigation UI primitives (`ScreenContent`, `SheetContent`). `@ScreenUi`, `@SheetUi`, and `@TabUi` tests pull these.
+- `appRootUiStubs` adds the same UI primitives plus a separate `androidx.compose.runtime.Composable` stub because `@AppRootUi` emits the annotation directly on the
+  generated extension. `@AppRootUi` tests pull these.
 
 The stubs are deliberately minimal. Their type signatures must match the constants in
 `codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/External.kt` exactly. Compilation in the test suite is the contract that catches drift: if
@@ -44,17 +47,23 @@ the stubs and `External.kt` disagree, end to end compilation fails. Updating one
 ## Goldens
 
 Each test asserts through `GoldenFileAssert.assertMatches(variant, fileName, actual)`. Goldens live under
-`codegen/processor-test/src/test/resources/golden/<variant>/<file>.kt`. Five variants:
+`codegen/processor-test/src/test/resources/golden/<variant>/<file>.kt`. Nine variants:
 
 - `simple/` for `@NavDestination(kind = SCREEN)` with plain `@Inject`.
 - `parameterized/` for `@NavDestination(kind = SCREEN)` with `@AssistedInject`.
 - `tab/` for `@NavDestination(kind = TAB_ROOT)`.
 - `screen-ui/` for `@ScreenUi`.
 - `sheet-ui/` for `@SheetUi`.
+- `tab-ui/` for `@TabUi`.
+- `child-presenter/` for `@ChildPresenter`.
+- `app-root/` for `@AppRoot`.
+- `app-root-ui/` for `@AppRootUi`.
 
 Test coverage is grouped by annotation, not by variant. `NavDestinationTest` covers all three `@NavDestination` kinds (SCREEN, OVERLAY, TAB_ROOT) plus the parameterized
-SCREEN variant. `ScreenUiTest` covers `@ScreenUi`. `SheetUiTest` covers `@SheetUi`. `ErrorPathTest` exercises the parser validation branches and asserts on the
-compilation messages rather than against a golden file.
+SCREEN variant. `ScreenUiTest` covers `@ScreenUi`. `SheetUiTest` covers `@SheetUi`. `TabUiTest` covers `@TabUi`. `ChildPresenterTest` covers `@ChildPresenter`. `AppRootTest`
+covers `@AppRoot` plus three error paths (missing `@AssistedInject`, missing nested factory, missing bound interface). `AppRootUiTest` covers `@AppRootUi` plus two error
+paths (no non-modifier parameter, presenter type mismatch). `ErrorPathTest` exercises the navigation-side parser validation branches and asserts on the compilation
+messages rather than against a golden file.
 
 `GoldenFileAssert` normalises both expected and actual by trimming trailing whitespace per line and trimming the file as a whole before comparing, so trailing newline
 drift does not cause flakes.

--- a/codegen/docs/examples.md
+++ b/codegen/docs/examples.md
@@ -18,6 +18,10 @@ next to the annotated symbol. For how each file is built from the input, see
 4. [`@NavDestination(kind = TAB_ROOT)`](#4-navdestinationkind--tab_root)
 5. [`@ScreenUi`](#5-screenui)
 6. [`@SheetUi`](#6-sheetui)
+7. [`@TabUi`](#7-tabui)
+8. [`@ChildPresenter`](#8-childpresenter)
+9. [`@AppRoot`](#9-approot)
+10. [`@AppRootUi`](#10-approotui)
 
 ## 1. `@NavDestination(kind = SCREEN)`, presenter with no runtime parameters
 
@@ -466,3 +470,290 @@ public object EpisodeSheetUiBinding {
 The overlay renderer does not receive a modifier. `SheetContent.content` is typed as `@Composable (SheetChild) -> Unit`. Modal layout decisions (a `ModalBottomSheet`, for
 example) belong inside the composable body, not at the call site. The annotated function still accepts a `modifier: Modifier = Modifier` parameter for consistency with
 other composables, but the generator does not forward it.
+
+## 7. `@TabUi`
+
+Use `@TabUi` on the Android `@Composable` function that renders one tab pager page. The annotation generates a `ScreenContent` binding identical in shape to the
+`@ScreenUi` output, but the generated predicate matches `TabChild<*>` rather than `ScreenDestination<*>`. Use it on the four bottom-bar tab pages (Discover, Library,
+Progress, Profile) where the active child is a `TabChild`-wrapped tab presenter rather than a `ScreenDestination`-wrapped routed screen.
+
+The previous section covered the overlay renderer (`@SheetUi`). The next section covers the parent-owned child presenter (`@ChildPresenter`). The next two cover the
+application root pair (`@AppRoot` and `@AppRootUi`).
+
+### Input
+
+```kotlin
+package com.thomaskioko.tvmaniac.discover.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.discover.presenter.DiscoverShowsPresenter
+import io.github.thomaskioko.codegen.annotations.TabUi
+
+@TabUi(presenter = DiscoverShowsPresenter::class, parentScope = ActivityScope::class)
+@Composable
+public fun DiscoverScreen(
+    presenter: DiscoverShowsPresenter,
+    modifier: Modifier = Modifier,
+) {
+    // ...
+}
+```
+
+### Generated: `DiscoverScreenUiBinding.kt`
+
+```kotlin
+package com.thomaskioko.tvmaniac.discover.ui.di
+
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.discover.presenter.DiscoverShowsPresenter
+import com.thomaskioko.tvmaniac.discover.ui.DiscoverScreen
+import com.thomaskioko.tvmaniac.home.nav.TabChild
+import com.thomaskioko.tvmaniac.navigation.ui.ScreenContent
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+
+@BindingContainer
+@ContributesTo(ActivityScope::class)
+public object DiscoverScreenUiBinding {
+    @Provides
+    @IntoSet
+    public fun provideDiscoverScreenContent(): ScreenContent = ScreenContent(
+        matches = { (it as? TabChild<*>)?.presenter is DiscoverShowsPresenter },
+        content = { child, modifier ->
+            DiscoverScreen(
+                presenter = (child as TabChild<*>).presenter as DiscoverShowsPresenter,
+                modifier = modifier,
+            )
+        },
+    )
+}
+```
+
+The output joins the same `Set<ScreenContent>` multibinding the navigation host iterates. The host treats `TabChild` and `ScreenDestination` the same way: it walks the
+set, finds the entry whose predicate returns `true` for the active child, and invokes that entry's `content` lambda.
+
+## 8. `@ChildPresenter`
+
+Use `@ChildPresenter` on a presenter class owned by a parent host presenter rather than navigated to through a route. The annotation generates a `<Presenter>ChildGraph`
+graph extension exposing the presenter as a property plus a nested factory contributing to the parent's scope. The pattern fits tab pagers (Tv Maniac's progress tab
+hosts an Up Next page and a Calendar page) and any other host presenter that constructs sibling presenters with `Decompose.childContext(key)`.
+
+### Input
+
+```kotlin
+package com.thomaskioko.tvmaniac.presentation.upnext
+
+@Inject
+@ChildPresenter(
+    scope = ProgressChildScope::class,
+    parentScope = ProgressRoot::class,
+)
+public class UpNextPresenter(
+    componentContext: ComponentContext,
+    // ... deps
+) : ComponentContext by componentContext
+```
+
+### Generated: `UpNextChildGraph.kt`
+
+```kotlin
+package com.thomaskioko.tvmaniac.presentation.upnext.di
+
+import com.arkivanov.decompose.ComponentContext
+import com.thomaskioko.tvmaniac.presentation.upnext.UpNextPresenter
+import com.thomaskioko.tvmaniac.progress.nav.ProgressChildScope
+import com.thomaskioko.tvmaniac.progress.nav.ProgressRoot
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.GraphExtension
+import dev.zacsweers.metro.Provides
+
+@GraphExtension(ProgressChildScope::class)
+public interface UpNextChildGraph {
+    public val upNextPresenter: UpNextPresenter
+
+    @ContributesTo(ProgressRoot::class)
+    @GraphExtension.Factory
+    public interface Factory {
+        public fun createUpNextGraph(@Provides componentContext: ComponentContext): UpNextChildGraph
+    }
+}
+```
+
+### Parent presenter wiring
+
+The parent host (here `ProgressPresenter`) takes one factory parameter per child. Each factory call gets a `Decompose.childContext(key)` so the children stay alive
+together with independent lifecycles:
+
+```kotlin
+@Inject
+@NavDestination(
+    route = ProgressRoot::class,
+    parentScope = ActivityScope::class,
+    kind = DestinationKind.TAB_ROOT,
+)
+public class ProgressPresenter(
+    componentContext: ComponentContext,
+    upNextGraphFactory: UpNextChildGraph.Factory,
+    calendarGraphFactory: CalendarChildGraph.Factory,
+) : ComponentContext by componentContext {
+    public val upNextPresenter: UpNextPresenter =
+        upNextGraphFactory.createUpNextGraph(childContext(key = "UpNext")).upNextPresenter
+    public val calendarPresenter: CalendarPresenter =
+        calendarGraphFactory.createCalendarGraph(childContext(key = "Calendar")).calendarPresenter
+}
+```
+
+The factory function name is unique per child (`create<BaseName>Graph`) so two child graphs contributing to the same parent scope (`ProgressRoot::class` here) do not
+collide.
+
+## 9. `@AppRoot`
+
+Use `@AppRoot` on the application's `@AssistedInject` root presenter implementation. The annotation generates the activity-scope `@BindingContainer` that wires the
+nested `@AssistedFactory` to the bound presenter interface. The output replaces the hand-written binding container the consumer would otherwise have to keep in sync
+with the factory function name and the bound interface name.
+
+`@AppRoot` differs from `@NavDestination` in two ways. The root has no route, so the annotation does not take a `route` parameter. The root is bound to its public
+interface at the parent scope rather than exposed through a `@GraphExtension`, so the generated artifact is a binding container, not a graph plus a destination binding.
+
+### Input
+
+```kotlin
+package com.thomaskioko.tvmaniac.presenter.root
+
+@AppRoot(parentScope = ActivityScope::class)
+@AssistedInject
+public class DefaultRootPresenter(
+    @Assisted componentContext: ComponentContext,
+    // ... deps
+) : RootPresenter, ComponentContext by componentContext {
+
+    @AssistedFactory
+    public fun interface Factory {
+        public fun create(componentContext: ComponentContext): DefaultRootPresenter
+    }
+}
+```
+
+Where `RootPresenter` is the bound interface declared in the same module:
+
+```kotlin
+public interface RootPresenter {
+    // ... presenter contract
+}
+```
+
+### Generated: `RootPresenterBindingContainer.kt`
+
+```kotlin
+package com.thomaskioko.tvmaniac.presenter.root.di
+
+@BindingContainer
+@ContributesTo(ActivityScope::class)
+public object RootPresenterBindingContainer {
+    @Provides
+    @SingleIn(ActivityScope::class)
+    public fun provideRootPresenter(componentContext: ComponentContext, factory: DefaultRootPresenter.Factory): RootPresenter = factory.create(componentContext)
+}
+```
+
+The `object` name is derived from the bound interface (`RootPresenter` becomes `RootPresenterBindingContainer`). The `@Provides` function name follows the same pattern
+(`provideRootPresenter`). The bound interface is inferred from the implementation's supertypes; `ComponentContext`, used as a delegate, is filtered out.
+
+## 10. `@AppRootUi`
+
+Use `@AppRootUi` on the host composable that wraps every other screen. The annotation generates a provider interface declaring one property for each non-modifier
+parameter on the composable plus a `@Composable AppRootProvider.AppRootContent(modifier)` extension that invokes the composable using the receiver's properties. The
+activity-scope graph extends the generated provider, and the activity invokes `graph.AppRootContent()` instead of forwarding each dependency by hand.
+
+The host composable is not a member of the `Set<ScreenContent>` multibinding the navigation system iterates. It is the host that publishes that set to its descendants.
+`@ScreenUi` does not apply for that reason. `@AppRootUi` exists so the codegen can emit a provider interface keyed off the composable's parameter list.
+
+### Input
+
+```kotlin
+package com.thomaskioko.tvmaniac.app.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.navigation.ui.ScreenContent
+import com.thomaskioko.tvmaniac.navigation.ui.SheetContent
+import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
+import io.github.thomaskioko.codegen.annotations.AppRootUi
+
+@AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)
+@Composable
+public fun RootScreen(
+    rootPresenter: RootPresenter,
+    screenContents: Set<ScreenContent>,
+    sheetContents: Set<SheetContent>,
+    modifier: Modifier = Modifier,
+) {
+    // ... compose UI here, including the navigation host
+}
+```
+
+### Generated: `RootScreenAppRootUiBinding.kt`
+
+```kotlin
+package com.thomaskioko.tvmaniac.app.ui.di
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.thomaskioko.tvmaniac.app.ui.RootScreen
+import com.thomaskioko.tvmaniac.navigation.ui.ScreenContent
+import com.thomaskioko.tvmaniac.navigation.ui.SheetContent
+import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
+import kotlin.collections.Set
+
+public interface AppRootProvider {
+    public val rootPresenter: RootPresenter
+
+    public val screenContents: Set<ScreenContent>
+
+    public val sheetContents: Set<SheetContent>
+}
+
+@Composable
+public fun AppRootProvider.AppRootContent(modifier: Modifier = Modifier) {
+    RootScreen(
+        rootPresenter = rootPresenter,
+        screenContents = screenContents,
+        sheetContents = sheetContents,
+        modifier = modifier,
+    )
+}
+```
+
+### Consumer wiring
+
+The consumer makes its activity-scope `@DependencyGraph` extend `AppRootProvider`. The graph already exposes the three properties; the only change is making the
+contract explicit:
+
+```kotlin
+@DependencyGraph(ActivityScope::class)
+public interface ActivityGraph : AppRootProvider {
+    override val rootPresenter: RootPresenter
+    override val screenContents: Set<ScreenContent>
+    override val sheetContents: Set<SheetContent>
+    // ... other graph members
+}
+```
+
+The activity then invokes the host with one call:
+
+```kotlin
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val graph = ActivityGraph.create(this)
+        setContent {
+            graph.AppRootContent()
+        }
+    }
+}
+```

--- a/codegen/docs/get-started.md
+++ b/codegen/docs/get-started.md
@@ -41,22 +41,34 @@ For how the processor turns each annotation into Metro plus Decompose code, see 
 
 ## Supported annotations
 
-Three annotations cover every variant the processor knows how to generate. See [annotations.md](annotations.md) for the full reference and [examples.md](examples.md) for
+Seven annotations cover every variant the processor knows how to generate. See [annotations.md](annotations.md) for the full reference and [examples.md](examples.md) for
 concrete inputs and outputs.
 
-The shared code presenter annotation (target `CLASS`, lives in the Kotlin Multiplatform `presenter` module):
+The shared code presenter annotations (target `CLASS`, live in the Kotlin Multiplatform `presenter` module):
 
 1. `@NavDestination(route, parentScope, kind)` is one annotation for every navigation destination. `kind` is one of `DestinationKind.SCREEN`, `OVERLAY`, or `TAB_ROOT`.
    - `SCREEN` and `OVERLAY` generate a graph scoped to the route plus a binding that contributes `NavDestination.Screen` (or `Overlay`) and `NavRouteBinding`. The
      processor auto-detects `@AssistedInject` with a nested `@AssistedFactory` to switch between the two presenter forms (one with no runtime parameters, one
      parameterized).
    - `TAB_ROOT` generates a graph scoped to the root plus a binding that contributes `NavDestination.TabRoot` and `NavRootBinding`. Plain `@Inject` only.
+2. `@AppRoot(parentScope)` marks the application's `@AssistedInject` root presenter implementation. The processor generates the `@BindingContainer` that wires the
+   nested `@AssistedFactory` to the bound presenter interface at the parent scope. The root is bound directly into the scope rather than exposed through a graph
+   extension because the activity holds it for the lifetime of the scope.
+3. `@ChildPresenter(scope, parentScope)` marks a presenter constructed by another presenter rather than navigated to through a route, such as a tab pager's pages. The
+   processor generates a `<Presenter>ChildGraph` graph extension exposing the presenter as a property plus a factory contributing to the parent host's scope. The parent
+   host takes one factory per child and instantiates each child with a `Decompose.childContext(key)`.
 
 The Android UI renderer annotations (target `FUNCTION`, live in the Android `ui` module):
 
-2. `@ScreenUi` marks a `@Composable` function as the Android renderer for a screen presenter defined in the shared Kotlin Multiplatform layer. It generates a
+4. `@ScreenUi` marks a `@Composable` function as the Android renderer for a screen presenter defined in the shared Kotlin Multiplatform layer. It generates a
    `@BindingContainer` object that contributes a `ScreenContent` into `Set<ScreenContent>` so the navigation host can iterate the set and render the right screen.
-3. `@SheetUi` marks a `@Composable` function as the Android renderer for a modal overlay presenter. It contributes a `SheetContent` into `Set<SheetContent>`.
+5. `@SheetUi` marks a `@Composable` function as the Android renderer for a modal overlay presenter. It contributes a `SheetContent` into `Set<SheetContent>`.
+6. `@TabUi` marks a `@Composable` function as the Android renderer for one tab pager page. The generated binding is identical in shape to a `@ScreenUi` binding except
+   that the predicate matches `TabChild<*>` rather than `ScreenDestination<*>`. Use it on the four bottom-bar tab pages where the active child is a `TabChild`-wrapped tab
+   presenter rather than a `ScreenDestination`-wrapped routed screen.
+7. `@AppRootUi(presenter, parentScope)` marks the host composable that wraps every other screen. The processor reads the function's non-modifier parameters and emits an
+   `AppRootProvider` interface plus a `@Composable AppRootProvider.AppRootContent(modifier)` extension. The activity-scope graph extends `AppRootProvider`, and the
+   activity invokes `graph.AppRootContent()` instead of forwarding each dependency by hand.
 
 ## Dependency
 
@@ -130,8 +142,48 @@ public fun DebugMenuScreen(
 ) { ... }
 ```
 
-Build the modules. KSP generates the graph and navigation binding into the presenter module's `di/` package, and the `ScreenContent` binding into the `ui` module's `di/`
-package. No further wiring is required inside each module.
+For the application's root, annotate the root presenter implementation and the host composable (one pair per project):
+
+```kotlin
+@AppRoot(parentScope = ActivityScope::class)
+@AssistedInject
+public class DefaultRootPresenter(
+    @Assisted componentContext: ComponentContext,
+    // ... deps
+) : RootPresenter, ComponentContext by componentContext {
+
+    @AssistedFactory
+    public fun interface Factory {
+        public fun create(componentContext: ComponentContext): DefaultRootPresenter
+    }
+}
+
+@AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)
+@Composable
+public fun RootScreen(
+    rootPresenter: RootPresenter,
+    screenContents: Set<ScreenContent>,
+    sheetContents: Set<SheetContent>,
+    modifier: Modifier = Modifier,
+) { ... }
+```
+
+Make the activity-scope graph extend the generated `AppRootProvider` so the generated extension resolves at the call site:
+
+```kotlin
+@DependencyGraph(ActivityScope::class)
+public interface ActivityGraph : AppRootProvider {
+    override val rootPresenter: RootPresenter
+    override val screenContents: Set<ScreenContent>
+    override val sheetContents: Set<SheetContent>
+    // ...
+}
+```
+
+The activity then invokes `graph.AppRootContent()` instead of forwarding each parameter to `RootScreen` by hand.
+
+Build the modules. KSP generates the graph and navigation binding into the presenter module's `di/` package, the `ScreenContent` binding into the `ui` module's `di/`
+package, and the root binding container plus the `AppRootProvider` interface into their respective modules. No further wiring is required inside each module.
 
 The app module must declare a direct `implementation` dependency on each feature `ui` module, not a transitive one. A transitive `implementation` dependency through a
 root `ui` module does not put the generated bindings on the app's compile classpath. Metro then reports a build error because the `Set<ScreenContent>` (or

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/AppRootTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/AppRootTest.kt
@@ -1,0 +1,174 @@
+package io.github.thomaskioko.codegen.processor
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCompilerApi::class)
+class AppRootTest {
+
+    @Test
+    fun `should generate binding container for AppRoot annotated implementation`() {
+        val sources = TestStubs.baseStubs.toMap() + mapOf(
+            "RootPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                public interface RootPresenter
+            """.trimIndent(),
+            "DefaultRootPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                import com.arkivanov.decompose.ComponentContext
+                import com.thomaskioko.tvmaniac.core.base.ActivityScope
+                import dev.zacsweers.metro.Assisted
+                import dev.zacsweers.metro.AssistedFactory
+                import dev.zacsweers.metro.AssistedInject
+                import io.github.thomaskioko.codegen.annotations.AppRoot
+
+                @AppRoot(parentScope = ActivityScope::class)
+                @AssistedInject
+                public class DefaultRootPresenter(
+                    @Assisted componentContext: ComponentContext,
+                ) : RootPresenter, ComponentContext by componentContext {
+
+                    @AssistedFactory
+                    public fun interface Factory {
+                        public fun create(componentContext: ComponentContext): DefaultRootPresenter
+                    }
+                }
+            """.trimIndent(),
+        )
+
+        val result = ProcessorTestRunner().run(sources)
+        assertEquals(
+            "Compilation failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+        )
+
+        val files = result.generatedFiles
+        assertEquals(
+            "Expected exactly 1 generated file, got ${files.keys}",
+            setOf("RootPresenterBindingContainer.kt"),
+            files.keys,
+        )
+
+        GoldenFileAssert.assertMatches(
+            "app-root",
+            "RootPresenterBindingContainer.kt",
+            files.getValue("RootPresenterBindingContainer.kt"),
+        )
+    }
+
+    @Test
+    fun `should fail when AppRoot is missing AssistedInject`() {
+        val sources = TestStubs.baseStubs.toMap() + mapOf(
+            "RootPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                public interface RootPresenter
+            """.trimIndent(),
+            "DefaultRootPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                import com.arkivanov.decompose.ComponentContext
+                import com.thomaskioko.tvmaniac.core.base.ActivityScope
+                import io.github.thomaskioko.codegen.annotations.AppRoot
+
+                @AppRoot(parentScope = ActivityScope::class)
+                public class DefaultRootPresenter(
+                    componentContext: ComponentContext,
+                ) : RootPresenter, ComponentContext by componentContext
+            """.trimIndent(),
+        )
+
+        val result = ProcessorTestRunner().run(sources)
+        assertEquals(
+            "Compilation should have failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.COMPILATION_ERROR,
+            result.exitCode,
+        )
+        assertTrue(
+            "Expected error about missing @AssistedInject. Messages were:\n${result.messages}",
+            result.messages.contains("requires @AssistedInject"),
+        )
+    }
+
+    @Test
+    fun `should fail when AppRoot is missing nested AssistedFactory`() {
+        val sources = TestStubs.baseStubs.toMap() + mapOf(
+            "RootPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                public interface RootPresenter
+            """.trimIndent(),
+            "DefaultRootPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                import com.arkivanov.decompose.ComponentContext
+                import com.thomaskioko.tvmaniac.core.base.ActivityScope
+                import dev.zacsweers.metro.Assisted
+                import dev.zacsweers.metro.AssistedInject
+                import io.github.thomaskioko.codegen.annotations.AppRoot
+
+                @AppRoot(parentScope = ActivityScope::class)
+                @AssistedInject
+                public class DefaultRootPresenter(
+                    @Assisted componentContext: ComponentContext,
+                ) : RootPresenter, ComponentContext by componentContext
+            """.trimIndent(),
+        )
+
+        val result = ProcessorTestRunner().run(sources)
+        assertEquals(
+            "Compilation should have failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.COMPILATION_ERROR,
+            result.exitCode,
+        )
+        assertTrue(
+            "Expected error about missing nested @AssistedFactory. Messages were:\n${result.messages}",
+            result.messages.contains("requires a nested @AssistedFactory"),
+        )
+    }
+
+    @Test
+    fun `should fail when AppRoot implementation has no bound interface`() {
+        val sources = TestStubs.baseStubs.toMap() + mapOf(
+            "DefaultRootPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                import com.arkivanov.decompose.ComponentContext
+                import com.thomaskioko.tvmaniac.core.base.ActivityScope
+                import dev.zacsweers.metro.Assisted
+                import dev.zacsweers.metro.AssistedFactory
+                import dev.zacsweers.metro.AssistedInject
+                import io.github.thomaskioko.codegen.annotations.AppRoot
+
+                @AppRoot(parentScope = ActivityScope::class)
+                @AssistedInject
+                public class DefaultRootPresenter(
+                    @Assisted componentContext: ComponentContext,
+                ) : ComponentContext by componentContext {
+
+                    @AssistedFactory
+                    public fun interface Factory {
+                        public fun create(componentContext: ComponentContext): DefaultRootPresenter
+                    }
+                }
+            """.trimIndent(),
+        )
+
+        val result = ProcessorTestRunner().run(sources)
+        assertEquals(
+            "Compilation should have failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.COMPILATION_ERROR,
+            result.exitCode,
+        )
+        assertTrue(
+            "Expected error about missing bound interface. Messages were:\n${result.messages}",
+            result.messages.contains("requires the implementation to extend exactly one"),
+        )
+    }
+}

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/AppRootUiTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/AppRootUiTest.kt
@@ -1,0 +1,144 @@
+package io.github.thomaskioko.codegen.processor
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCompilerApi::class)
+class AppRootUiTest {
+
+    @Test
+    fun `should generate AppRootProvider and extension for AppRootUi composable`() {
+        val sources = TestStubs.appRootUiStubs.toMap() + mapOf(
+            "RootPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                public interface RootPresenter
+            """.trimIndent(),
+            "RootScreen.kt" to """
+                package com.thomaskioko.tvmaniac.app.ui
+
+                import androidx.compose.runtime.Composable
+                import androidx.compose.ui.Modifier
+                import com.thomaskioko.tvmaniac.core.base.ActivityScope
+                import com.thomaskioko.tvmaniac.navigation.ui.ScreenContent
+                import com.thomaskioko.tvmaniac.navigation.ui.SheetContent
+                import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
+                import io.github.thomaskioko.codegen.annotations.AppRootUi
+
+                @AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)
+                @Composable
+                public fun RootScreen(
+                    rootPresenter: RootPresenter,
+                    screenContents: Set<ScreenContent>,
+                    sheetContents: Set<SheetContent>,
+                    modifier: Modifier = Modifier,
+                ) {
+                }
+            """.trimIndent(),
+        )
+
+        val result = ProcessorTestRunner().run(sources)
+        assertEquals(
+            "Compilation failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+        )
+
+        val files = result.generatedFiles
+        assertEquals(
+            "Expected exactly 1 generated file, got ${files.keys}",
+            setOf("RootScreenAppRootUiBinding.kt"),
+            files.keys,
+        )
+
+        GoldenFileAssert.assertMatches(
+            "app-root-ui",
+            "RootScreenAppRootUiBinding.kt",
+            files.getValue("RootScreenAppRootUiBinding.kt"),
+        )
+    }
+
+    @Test
+    fun `should fail when AppRootUi has no non-modifier parameters`() {
+        val sources = TestStubs.appRootUiStubs.toMap() + mapOf(
+            "RootPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                public interface RootPresenter
+            """.trimIndent(),
+            "RootScreen.kt" to """
+                package com.thomaskioko.tvmaniac.app.ui
+
+                import androidx.compose.runtime.Composable
+                import androidx.compose.ui.Modifier
+                import com.thomaskioko.tvmaniac.core.base.ActivityScope
+                import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
+                import io.github.thomaskioko.codegen.annotations.AppRootUi
+
+                @AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)
+                @Composable
+                public fun RootScreen(modifier: Modifier = Modifier) {
+                }
+            """.trimIndent(),
+        )
+
+        val result = ProcessorTestRunner().run(sources)
+        assertEquals(
+            "Compilation should have failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.COMPILATION_ERROR,
+            result.exitCode,
+        )
+        assertTrue(
+            "Expected error about missing non-modifier parameter. Messages were:\n${result.messages}",
+            result.messages.contains("at least one"),
+        )
+    }
+
+    @Test
+    fun `should fail when first parameter type does not match presenter argument`() {
+        val sources = TestStubs.appRootUiStubs.toMap() + mapOf(
+            "RootPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                public interface RootPresenter
+            """.trimIndent(),
+            "OtherPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.presenter.root
+
+                public class OtherPresenter
+            """.trimIndent(),
+            "RootScreen.kt" to """
+                package com.thomaskioko.tvmaniac.app.ui
+
+                import androidx.compose.runtime.Composable
+                import androidx.compose.ui.Modifier
+                import com.thomaskioko.tvmaniac.core.base.ActivityScope
+                import com.thomaskioko.tvmaniac.presenter.root.OtherPresenter
+                import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
+                import io.github.thomaskioko.codegen.annotations.AppRootUi
+
+                @AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)
+                @Composable
+                public fun RootScreen(
+                    other: OtherPresenter,
+                    modifier: Modifier = Modifier,
+                ) {
+                }
+            """.trimIndent(),
+        )
+
+        val result = ProcessorTestRunner().run(sources)
+        assertEquals(
+            "Compilation should have failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.COMPILATION_ERROR,
+            result.exitCode,
+        )
+        assertTrue(
+            "Expected error about parameter type mismatch. Messages were:\n${result.messages}",
+            result.messages.contains("does not match the declared presenter type"),
+        )
+    }
+}

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/TabUiTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/TabUiTest.kt
@@ -1,0 +1,58 @@
+package io.github.thomaskioko.codegen.processor
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCompilerApi::class)
+class TabUiTest {
+
+    @Test
+    fun `should generate ScreenContent binding for TabUi composable matching TabChild`() {
+        val sources = TestStubs.tabUiStubs.toMap() + mapOf(
+            "DiscoverShowsPresenter.kt" to """
+                package com.thomaskioko.tvmaniac.discover.presenter
+
+                public class DiscoverShowsPresenter
+            """.trimIndent(),
+            "DiscoverScreen.kt" to """
+                package com.thomaskioko.tvmaniac.discover.ui
+
+                import androidx.compose.ui.Composable
+                import androidx.compose.ui.Modifier
+                import com.thomaskioko.tvmaniac.core.base.ActivityScope
+                import com.thomaskioko.tvmaniac.discover.presenter.DiscoverShowsPresenter
+                import io.github.thomaskioko.codegen.annotations.TabUi
+
+                @TabUi(presenter = DiscoverShowsPresenter::class, parentScope = ActivityScope::class)
+                @Composable
+                public fun DiscoverScreen(
+                    presenter: DiscoverShowsPresenter,
+                    modifier: Modifier = Modifier,
+                ) {
+                }
+            """.trimIndent(),
+        )
+
+        val result = ProcessorTestRunner().run(sources)
+        assertEquals(
+            "Compilation failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+        )
+
+        val files = result.generatedFiles
+        assertEquals(
+            "Expected exactly 1 generated file, got ${files.keys}",
+            setOf("DiscoverScreenUiBinding.kt"),
+            files.keys,
+        )
+
+        GoldenFileAssert.assertMatches(
+            "tab-ui",
+            "DiscoverScreenUiBinding.kt",
+            files.getValue("DiscoverScreenUiBinding.kt"),
+        )
+    }
+}

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/TestStubs.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/TestStubs.kt
@@ -171,6 +171,9 @@ internal object TestStubs {
 
         @Target(AnnotationTarget.FUNCTION)
         public annotation class IntoSet
+
+        @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+        public annotation class SingleIn(val scope: KClass<*>)
     """.trimIndent()
 
     val composeUi = "ComposeUi.kt" to """
@@ -179,6 +182,13 @@ internal object TestStubs {
         public interface Modifier {
             public companion object : Modifier
         }
+
+        @Target(AnnotationTarget.FUNCTION, AnnotationTarget.TYPE, AnnotationTarget.PROPERTY_GETTER)
+        public annotation class Composable
+    """.trimIndent()
+
+    val composeRuntime = "ComposeRuntime.kt" to """
+        package androidx.compose.runtime
 
         @Target(AnnotationTarget.FUNCTION, AnnotationTarget.TYPE, AnnotationTarget.PROPERTY_GETTER)
         public annotation class Composable
@@ -214,4 +224,9 @@ internal object TestStubs {
     val tabStubs: List<Pair<String, String>> = baseStubs + listOf(homeNav, homeConfig)
 
     val uiStubs: List<Pair<String, String>> = baseStubs + listOf(composeUi, navigationUi)
+
+    val tabUiStubs: List<Pair<String, String>> = uiStubs + listOf(homeNav)
+
+    val appRootUiStubs: List<Pair<String, String>> =
+        baseStubs + listOf(composeUi, composeRuntime, navigationUi)
 }

--- a/codegen/processor-test/src/test/resources/golden/app-root-ui/RootScreenAppRootUiBinding.kt
+++ b/codegen/processor-test/src/test/resources/golden/app-root-ui/RootScreenAppRootUiBinding.kt
@@ -1,0 +1,27 @@
+package com.thomaskioko.tvmaniac.app.ui.di
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.thomaskioko.tvmaniac.app.ui.RootScreen
+import com.thomaskioko.tvmaniac.navigation.ui.ScreenContent
+import com.thomaskioko.tvmaniac.navigation.ui.SheetContent
+import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
+import kotlin.collections.Set
+
+public interface AppRootProvider {
+    public val rootPresenter: RootPresenter
+
+    public val screenContents: Set<ScreenContent>
+
+    public val sheetContents: Set<SheetContent>
+}
+
+@Composable
+public fun AppRootProvider.AppRootContent(modifier: Modifier = Modifier) {
+    RootScreen(
+        rootPresenter = rootPresenter,
+        screenContents = screenContents,
+        sheetContents = sheetContents,
+        modifier = modifier,
+    )
+}

--- a/codegen/processor-test/src/test/resources/golden/app-root/RootPresenterBindingContainer.kt
+++ b/codegen/processor-test/src/test/resources/golden/app-root/RootPresenterBindingContainer.kt
@@ -1,0 +1,18 @@
+package com.thomaskioko.tvmaniac.presenter.root.di
+
+import com.arkivanov.decompose.ComponentContext
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.presenter.root.DefaultRootPresenter
+import com.thomaskioko.tvmaniac.presenter.root.RootPresenter
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+@BindingContainer
+@ContributesTo(ActivityScope::class)
+public object RootPresenterBindingContainer {
+    @Provides
+    @SingleIn(ActivityScope::class)
+    public fun provideRootPresenter(componentContext: ComponentContext, factory: DefaultRootPresenter.Factory): RootPresenter = factory.create(componentContext)
+}

--- a/codegen/processor-test/src/test/resources/golden/tab-ui/DiscoverScreenUiBinding.kt
+++ b/codegen/processor-test/src/test/resources/golden/tab-ui/DiscoverScreenUiBinding.kt
@@ -1,0 +1,27 @@
+package com.thomaskioko.tvmaniac.discover.ui.di
+
+import com.thomaskioko.tvmaniac.core.base.ActivityScope
+import com.thomaskioko.tvmaniac.discover.presenter.DiscoverShowsPresenter
+import com.thomaskioko.tvmaniac.discover.ui.DiscoverScreen
+import com.thomaskioko.tvmaniac.home.nav.TabChild
+import com.thomaskioko.tvmaniac.navigation.ui.ScreenContent
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+
+@BindingContainer
+@ContributesTo(ActivityScope::class)
+public object DiscoverScreenUiBinding {
+    @Provides
+    @IntoSet
+    public fun provideDiscoverScreenContent(): ScreenContent = ScreenContent(
+        matches = { (it as? TabChild<*>)?.presenter is DiscoverShowsPresenter },
+        content = { child, modifier ->
+            DiscoverScreen(
+                presenter = (child as TabChild<*>).presenter as DiscoverShowsPresenter,
+                modifier = modifier,
+            )
+        },
+    )
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/Constants.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/Constants.kt
@@ -17,13 +17,22 @@ internal object Constants {
     const val DESTINATION_KIND: String = "DestinationKind"
     const val SCREEN_UI: String = "ScreenUi"
     const val SHEET_UI: String = "SheetUi"
+    const val TAB_UI: String = "TabUi"
+    const val CHILD_PRESENTER: String = "ChildPresenter"
+    const val APP_ROOT: String = "AppRoot"
+    const val APP_ROOT_UI: String = "AppRootUi"
 
     const val NAV_DESTINATION_FQN: String = "$ANNOTATIONS_PACKAGE.$NAV_DESTINATION"
     const val DESTINATION_KIND_FQN: String = "$ANNOTATIONS_PACKAGE.$DESTINATION_KIND"
     const val SCREEN_UI_FQN: String = "$ANNOTATIONS_PACKAGE.$SCREEN_UI"
     const val SHEET_UI_FQN: String = "$ANNOTATIONS_PACKAGE.$SHEET_UI"
+    const val TAB_UI_FQN: String = "$ANNOTATIONS_PACKAGE.$TAB_UI"
+    const val CHILD_PRESENTER_FQN: String = "$ANNOTATIONS_PACKAGE.$CHILD_PRESENTER"
+    const val APP_ROOT_FQN: String = "$ANNOTATIONS_PACKAGE.$APP_ROOT"
+    const val APP_ROOT_UI_FQN: String = "$ANNOTATIONS_PACKAGE.$APP_ROOT_UI"
 
     const val METRO_PACKAGE: String = "dev.zacsweers.metro"
     const val ASSISTED_FACTORY_FQN: String = "$METRO_PACKAGE.AssistedFactory"
     const val ASSISTED_FQN: String = "$METRO_PACKAGE.Assisted"
+    const val ASSISTED_INJECT_FQN: String = "$METRO_PACKAGE.AssistedInject"
 }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessor.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessor.kt
@@ -10,22 +10,29 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ksp.writeTo
+import io.github.thomaskioko.codegen.processor.codegen.AppRootBindingGenerator
+import io.github.thomaskioko.codegen.processor.codegen.AppRootUiBindingGenerator
+import io.github.thomaskioko.codegen.processor.codegen.ChildGraphGenerator
 import io.github.thomaskioko.codegen.processor.codegen.FileGenerator
 import io.github.thomaskioko.codegen.processor.codegen.UiBindingGenerator
 import io.github.thomaskioko.codegen.processor.data.NavData
 import io.github.thomaskioko.codegen.processor.data.UiBindingKind
+import io.github.thomaskioko.codegen.processor.parser.parseAppRootData
+import io.github.thomaskioko.codegen.processor.parser.parseAppRootUiData
+import io.github.thomaskioko.codegen.processor.parser.parseChildPresenterData
 import io.github.thomaskioko.codegen.processor.parser.parseNavDestinationData
 import io.github.thomaskioko.codegen.processor.parser.parseUiBindingData
 
 /**
- * The KSP processor that turns navigation codegen annotations into Metro graph extensions and
+ * KSP processor that turns navigation codegen annotations into Metro graph extensions and
  * navigation bindings. Loaded once per build by KSP through [NavigationCodegenProcessorProvider].
  *
- * The processor walks three annotation queries in order: `@NavDestination` (presenter classes),
- * `@ScreenUi`, and `@SheetUi` (composable functions). Each match goes through a parser to produce
- * a typed intermediate representation, then through a generator to produce one or more
- * [FileSpec] outputs that KSP writes to disk. The full pipeline and the rationale behind each
- * step are documented in `codegen/docs/architecture/pipeline.md`.
+ * The processor walks seven annotation queries in order. Three target presenter classes in shared
+ * Kotlin Multiplatform modules: `@NavDestination`, `@AppRoot`, and `@ChildPresenter`. Four target
+ * composable functions in Android UI modules: `@ScreenUi`, `@SheetUi`, `@TabUi`, and `@AppRootUi`.
+ * Each match goes through a parser to produce a typed intermediate representation, then through a
+ * generator to produce one or more [FileSpec] outputs that KSP writes to disk. Full pipeline and
+ * rationale behind each step live in `codegen/docs/architecture/pipeline.md`.
  *
  * The processor never throws on bad input. Every validation failure is reported through
  * [KSPLogger.error] pinned to the offending symbol, and KSP turns that into a compile error at
@@ -42,7 +49,7 @@ public class NavigationCodegenProcessor(
     private val logger: KSPLogger,
 ) : SymbolProcessor {
     /**
-     * Runs one KSP round. Iterates the three annotations the processor knows about, hands each
+     * Runs one KSP round. Iterates the seven annotations the processor knows about, hands each
      * symbol to the matching parser and generator, and returns an empty list of deferred symbols
      * because this processor produces nothing on subsequent rounds.
      *
@@ -56,7 +63,76 @@ public class NavigationCodegenProcessor(
         }
         processUiBinding(resolver, Constants.SCREEN_UI_FQN, Constants.SCREEN_UI, UiBindingKind.Screen)
         processUiBinding(resolver, Constants.SHEET_UI_FQN, Constants.SHEET_UI, UiBindingKind.Sheet)
+        processUiBinding(resolver, Constants.TAB_UI_FQN, Constants.TAB_UI, UiBindingKind.Tab)
+        processAppRoot(resolver)
+        processAppRootUi(resolver)
+        processChildPresenter(resolver)
         return emptyList()
+    }
+
+    /**
+     * Processes the `@ChildPresenter` annotation. Each annotated class produces one
+     * `<Presenter>ChildGraph` graph extension.
+     */
+    private fun processChildPresenter(resolver: Resolver) {
+        for (symbol in resolver.getSymbolsWithAnnotation(Constants.CHILD_PRESENTER_FQN)) {
+            val declaration = symbol as? KSClassDeclaration ?: run {
+                logger.error("@${Constants.CHILD_PRESENTER} can only be applied to classes", symbol)
+                continue
+            }
+            val data = parseChildPresenterData(declaration, logger) ?: continue
+            writeFiles(declaration, listOf(ChildGraphGenerator.generate(data)))
+        }
+    }
+
+    /**
+     * Processes the `@AppRoot` annotation. For each annotated implementation, [parseAppRootData]
+     * produces an [io.github.thomaskioko.codegen.processor.data.AppRootData] and
+     * [AppRootBindingGenerator] emits one binding file. A symbol that is not a class is reported
+     * as a compile error at its declaration site.
+     *
+     * @param resolver KSP's lookup interface for the current round.
+     */
+    private fun processAppRoot(resolver: Resolver) {
+        for (symbol in resolver.getSymbolsWithAnnotation(Constants.APP_ROOT_FQN)) {
+            val declaration = symbol as? KSClassDeclaration ?: run {
+                logger.error("@${Constants.APP_ROOT} can only be applied to classes", symbol)
+                continue
+            }
+            val data = parseAppRootData(declaration, logger) ?: continue
+            writeFiles(declaration, listOf(AppRootBindingGenerator.generate(data)))
+        }
+    }
+
+    /**
+     * Processes the `@AppRootUi` annotation. For each annotated composable, [parseAppRootUiData]
+     * produces an [io.github.thomaskioko.codegen.processor.data.AppRootUiData] and
+     * [AppRootUiBindingGenerator] emits one binding file containing the `AppRootProvider`
+     * interface and the `AppRootContent` extension. A symbol that is not a function is reported
+     * as a compile error at its declaration site. More than one annotated function in a single
+     * round is reported as a compile error pinned to the second.
+     *
+     * @param resolver KSP's lookup interface for the current round.
+     */
+    private fun processAppRootUi(resolver: Resolver) {
+        var seen = false
+        for (symbol in resolver.getSymbolsWithAnnotation(Constants.APP_ROOT_UI_FQN)) {
+            val function = symbol as? KSFunctionDeclaration ?: run {
+                logger.error("@${Constants.APP_ROOT_UI} can only be applied to functions", symbol)
+                continue
+            }
+            if (seen) {
+                logger.error(
+                    "@${Constants.APP_ROOT_UI} may be applied to at most one composable per " +
+                        "compilation. Remove the duplicate.",
+                    function,
+                )
+                continue
+            }
+            val data = parseAppRootUiData(function, logger) ?: continue
+            writeFunctionFiles(function, listOf(AppRootUiBindingGenerator.generate(data)))
+            seen = true
+        }
     }
 
     /**

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/AppRootBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/AppRootBindingGenerator.kt
@@ -1,0 +1,73 @@
+package io.github.thomaskioko.codegen.processor.codegen
+
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.TypeSpec
+import io.github.thomaskioko.codegen.processor.data.AppRootData
+import io.github.thomaskioko.codegen.processor.util.ComponentContext
+import io.github.thomaskioko.codegen.processor.util.FOUR_SPACE_INDENT
+import io.github.thomaskioko.codegen.processor.util.Provides
+import io.github.thomaskioko.codegen.processor.util.bindingContainer
+import io.github.thomaskioko.codegen.processor.util.contributesTo
+import io.github.thomaskioko.codegen.processor.util.singleIn
+
+/**
+ * Generates the binding file for an `@AppRoot` annotated presenter implementation.
+ *
+ * The output is a `@BindingContainer @ContributesTo(parentScope) object <InterfaceName>BindingContainer`
+ * with one `@Provides @SingleIn(parentScope)` function that takes a `ComponentContext` and the
+ * nested `Factory`, and returns the bound interface. The function body invokes the factory's
+ * single function with the supplied `ComponentContext`.
+ *
+ * The output replaces the hand-written binding container the consumer would otherwise have to
+ * keep in sync with the implementation's factory function name and the bound interface name.
+ */
+internal object AppRootBindingGenerator {
+
+    /**
+     * Generates the binding file for one `@AppRoot` implementation.
+     *
+     * @param data The parsed annotation, which carries the implementation, the bound interface,
+     *   the factory class and function names, and the parent scope.
+     * @return The generated binding file as a KotlinPoet [FileSpec].
+     */
+    fun generate(data: AppRootData): FileSpec {
+        val factoryParam = ParameterSpec.builder("factory", data.factoryClassName).build()
+        val componentContextParam = ParameterSpec.builder("componentContext", ComponentContext).build()
+
+        val provideFun = FunSpec.builder(data.provideFunName)
+            .addModifiers(KModifier.PUBLIC)
+            .addAnnotation(Provides)
+            .addAnnotation(singleIn(data.parentScope))
+            .addParameter(componentContextParam)
+            .addParameter(factoryParam)
+            .returns(data.interfaceClassName)
+            .addCode(buildProvideBody(data))
+            .build()
+
+        val bindingObject = TypeSpec.objectBuilder(data.bindingClassName)
+            .addModifiers(KModifier.PUBLIC)
+            .addAnnotation(bindingContainer())
+            .addAnnotation(contributesTo(data.parentScope))
+            .addFunction(provideFun)
+            .build()
+
+        return FileSpec.builder(data.bindingClassName)
+            .indent(FOUR_SPACE_INDENT)
+            .addType(bindingObject)
+            .build()
+    }
+
+    /**
+     * Generates the body of the `@Provides` function. The body returns a single expression that
+     * invokes the factory function with the supplied `ComponentContext`.
+     *
+     * @param data The parsed annotation.
+     * @return A KotlinPoet [CodeBlock] that becomes the body of the `@Provides` function.
+     */
+    private fun buildProvideBody(data: AppRootData): CodeBlock =
+        CodeBlock.of("return factory.%L(componentContext)\n", data.factoryFunctionName)
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/AppRootUiBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/AppRootUiBindingGenerator.kt
@@ -1,0 +1,95 @@
+package io.github.thomaskioko.codegen.processor.codegen
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import io.github.thomaskioko.codegen.processor.data.AppRootUiData
+import io.github.thomaskioko.codegen.processor.util.Composable
+import io.github.thomaskioko.codegen.processor.util.FOUR_SPACE_INDENT
+import io.github.thomaskioko.codegen.processor.util.Modifier
+
+/**
+ * Generates the binding file for an `@AppRootUi` annotated composable.
+ *
+ * The output contains two declarations:
+ *
+ * - An `AppRootProvider` interface declaring one `val` for each non-modifier parameter on the
+ *   annotated composable.
+ * - A `@Composable AppRootProvider.AppRootContent(modifier: Modifier)` extension that invokes the
+ *   annotated composable using the receiver's properties.
+ *
+ * The consumer makes its activity-scope `@DependencyGraph` extend `AppRootProvider`. The activity
+ * call site collapses from one argument per dependency to one extension call.
+ */
+internal object AppRootUiBindingGenerator {
+
+    /**
+     * Generates the binding file for one `@AppRootUi` composable.
+     *
+     * @param data The parsed annotation, which carries the composable function reference, the
+     *   parameter list, and whether the composable accepts a `Modifier`.
+     * @return The generated binding file as a KotlinPoet [FileSpec].
+     */
+    fun generate(data: AppRootUiData): FileSpec {
+        val providerInterface = TypeSpec.interfaceBuilder(data.providerInterfaceName)
+            .addModifiers(KModifier.PUBLIC)
+            .also { builder ->
+                data.parameters.forEach { parameter ->
+                    builder.addProperty(
+                        PropertySpec.builder(parameter.name, parameter.type)
+                            .addModifiers(KModifier.PUBLIC)
+                            .build(),
+                    )
+                }
+            }
+            .build()
+
+        val composableAnnotation = AnnotationSpec.builder(Composable).build()
+
+        val modifierParam = ParameterSpec.builder("modifier", Modifier)
+            .defaultValue("%T", Modifier)
+            .build()
+
+        val extension = FunSpec.builder("AppRootContent")
+            .addModifiers(KModifier.PUBLIC)
+            .addAnnotation(composableAnnotation)
+            .receiver(data.providerInterfaceName)
+            .addParameter(modifierParam)
+            .addCode(buildExtensionBody(data))
+            .build()
+
+        return FileSpec.builder(data.bindingClassName)
+            .indent(FOUR_SPACE_INDENT)
+            .addType(providerInterface)
+            .addFunction(extension)
+            .build()
+    }
+
+    /**
+     * Generates the body of the `AppRootContent` extension. The body invokes the annotated
+     * composable, passing each parameter from the matching property on the receiver. When the
+     * composable accepts a `modifier` parameter, the extension's `modifier` argument is forwarded.
+     *
+     * @param data The parsed annotation.
+     * @return A KotlinPoet [CodeBlock] that becomes the body of the extension.
+     */
+    private fun buildExtensionBody(data: AppRootUiData): CodeBlock {
+        val builder = CodeBlock.builder()
+            .add("%M(\n", data.composableFunction)
+            .indent()
+        data.parameters.forEach { parameter ->
+            builder.add("%L = %L,\n", parameter.name, parameter.name)
+        }
+        if (data.hasModifier) {
+            builder.add("modifier = modifier,\n")
+        }
+        builder.unindent()
+            .add(")\n")
+        return builder.build()
+    }
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/ChildGraphGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/ChildGraphGenerator.kt
@@ -1,0 +1,67 @@
+package io.github.thomaskioko.codegen.processor.codegen
+
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import io.github.thomaskioko.codegen.processor.data.ChildPresenterData
+import io.github.thomaskioko.codegen.processor.util.ComponentContext
+import io.github.thomaskioko.codegen.processor.util.FOUR_SPACE_INDENT
+import io.github.thomaskioko.codegen.processor.util.Provides
+import io.github.thomaskioko.codegen.processor.util.contributesTo
+import io.github.thomaskioko.codegen.processor.util.graphExtension
+import io.github.thomaskioko.codegen.processor.util.graphExtensionFactory
+
+/**
+ * Generates the graph extension file for a `@ChildPresenter` annotated class.
+ *
+ * The output is a `@GraphExtension(scope) interface <Presenter>ChildGraph` exposing the
+ * presenter as a property and a `@ContributesTo(parentScope) @GraphExtension.Factory` nested
+ * interface that takes a `ComponentContext` and returns the graph.
+ */
+internal object ChildGraphGenerator {
+
+    /**
+     * Generates the graph extension file for one `@ChildPresenter` annotated class.
+     *
+     * @param data The parsed annotation, which carries the presenter class, the graph scope, and
+     *   the parent scope.
+     * @return The generated graph file as a KotlinPoet [FileSpec].
+     */
+    fun generate(data: ChildPresenterData): FileSpec {
+        val factoryFun = FunSpec.builder(data.graphFactoryFunName)
+            .addModifiers(KModifier.PUBLIC, KModifier.ABSTRACT)
+            .addParameter(
+                ParameterSpec.builder("componentContext", ComponentContext)
+                    .addAnnotation(Provides)
+                    .build(),
+            )
+            .returns(data.graphClassName)
+            .build()
+
+        val factoryInterface = TypeSpec.interfaceBuilder(data.graphClassName.nestedClass("Factory"))
+            .addModifiers(KModifier.PUBLIC)
+            .addAnnotation(contributesTo(data.parentScope))
+            .addAnnotation(graphExtensionFactory())
+            .addFunction(factoryFun)
+            .build()
+
+        val presenterProperty = PropertySpec.builder(data.graphPropertyName, data.presenterClass)
+            .addModifiers(KModifier.PUBLIC)
+            .build()
+
+        val graphInterface = TypeSpec.interfaceBuilder(data.graphClassName)
+            .addModifiers(KModifier.PUBLIC)
+            .addAnnotation(graphExtension(data.scope))
+            .addProperty(presenterProperty)
+            .addType(factoryInterface)
+            .build()
+
+        return FileSpec.builder(data.graphClassName)
+            .indent(FOUR_SPACE_INDENT)
+            .addType(graphInterface)
+            .build()
+    }
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/UiBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/UiBindingGenerator.kt
@@ -15,6 +15,7 @@ import io.github.thomaskioko.codegen.processor.util.ScreenContent
 import io.github.thomaskioko.codegen.processor.util.ScreenDestination
 import io.github.thomaskioko.codegen.processor.util.SheetContent
 import io.github.thomaskioko.codegen.processor.util.SheetDestination
+import io.github.thomaskioko.codegen.processor.util.TabChild
 import io.github.thomaskioko.codegen.processor.util.bindingContainer
 import io.github.thomaskioko.codegen.processor.util.contributesTo
 
@@ -150,5 +151,6 @@ internal object UiBindingGenerator {
     private fun variantFor(kind: UiBindingKind): Variant = when (kind) {
         UiBindingKind.Screen -> Variant(ScreenContent, ScreenDestination, forwardsModifier = true)
         UiBindingKind.Sheet -> Variant(SheetContent, SheetDestination, forwardsModifier = false)
+        UiBindingKind.Tab -> Variant(ScreenContent, TabChild, forwardsModifier = true)
     }
 }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/AppRootData.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/AppRootData.kt
@@ -1,0 +1,89 @@
+package io.github.thomaskioko.codegen.processor.data
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.TypeName
+
+/**
+ * Structured representation of an `@AppRoot` annotated presenter implementation. Produced by
+ * [io.github.thomaskioko.codegen.processor.parser.parseAppRootData] and consumed by
+ * [io.github.thomaskioko.codegen.processor.codegen.AppRootBindingGenerator].
+ *
+ * The generator emits a `@BindingContainer @ContributesTo(parentScope) object` named
+ * `<InterfaceName>BindingContainer` containing one `@Provides @SingleIn(parentScope)` function
+ * that takes a `ComponentContext` and the nested factory, and returns the bound interface.
+ *
+ * @property implClassName The annotated `@AssistedInject` implementation class.
+ * @property interfaceClassName The single non-marker supertype the implementation extends. The
+ *   generated provider returns this type.
+ * @property factoryClassName The nested `@AssistedFactory` interface inside [implClassName]. The
+ *   generated provider takes this as a parameter and calls its factory function.
+ * @property factoryFunctionName The name of the factory function inside [factoryClassName] that
+ *   takes a `ComponentContext` and returns the implementation.
+ * @property parentScope The parent dependency injection scope hosting the generated binding
+ *   (typically `ActivityScope`).
+ * @property packageName The package the generated binding lands in. Equals the implementation's
+ *   package plus a `.di` suffix.
+ */
+internal data class AppRootData(
+    val implClassName: ClassName,
+    val interfaceClassName: ClassName,
+    val factoryClassName: ClassName,
+    val factoryFunctionName: String,
+    val parentScope: ClassName,
+    val packageName: String,
+) {
+    val bindingClassName: ClassName =
+        ClassName(packageName, "${interfaceClassName.simpleName}BindingContainer")
+    val provideFunName: String =
+        "provide${interfaceClassName.simpleName}"
+}
+
+/**
+ * Structured representation of an `@AppRootUi` annotated composable. Produced by
+ * [io.github.thomaskioko.codegen.processor.parser.parseAppRootUiData] and consumed by
+ * [io.github.thomaskioko.codegen.processor.codegen.AppRootUiBindingGenerator].
+ *
+ * The generator emits an `AppRootProvider` interface declaring one `val` for each entry in
+ * [parameters], plus a `@Composable AppRootProvider.AppRootContent(modifier)` extension that
+ * invokes the annotated composable using the receiver's properties.
+ *
+ * @property composableFunction Reference to the annotated composable. Held as a [MemberName] so
+ *   the generated code calls the composable as a top level function through KotlinPoet's `%M`
+ *   interpolation.
+ * @property packageName The composable's package. The generated binding lands in `$packageName.di`.
+ * @property parameters The composable's non-modifier parameters in declaration order. Each becomes
+ *   a property on the generated `AppRootProvider` interface.
+ * @property hasModifier Whether the composable accepts a `modifier: Modifier` parameter. The
+ *   generated extension forwards the receiver's modifier when `true` and omits the parameter
+ *   when `false`.
+ * @property parentScope The parent dependency injection scope hosting the generated artifacts
+ *   (typically `ActivityScope`).
+ */
+internal data class AppRootUiData(
+    val composableFunction: MemberName,
+    val packageName: String,
+    val parameters: List<AppRootUiParameter>,
+    val hasModifier: Boolean,
+    val parentScope: ClassName,
+) {
+    val functionName: String get() = composableFunction.simpleName
+    val bindingClassName: ClassName =
+        ClassName("$packageName.di", "${functionName}AppRootUiBinding")
+    val providerInterfaceName: ClassName =
+        ClassName("$packageName.di", "AppRootProvider")
+}
+
+/**
+ * One non-modifier parameter on an `@AppRootUi` annotated composable. Each becomes a property on
+ * the generated `AppRootProvider` interface.
+ *
+ * @property name Parameter name as written on the composable. Used as both the property name on
+ *   the provider interface and the argument name in the generated extension's call to the
+ *   composable.
+ * @property type Parameter type. Used as the property type on the provider interface.
+ */
+internal data class AppRootUiParameter(
+    val name: String,
+    val type: TypeName,
+)

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/ChildPresenterData.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/ChildPresenterData.kt
@@ -1,0 +1,31 @@
+package io.github.thomaskioko.codegen.processor.data
+
+import com.squareup.kotlinpoet.ClassName
+
+/**
+ * Structured representation of a `@ChildPresenter` annotated presenter class. Produced by
+ * [io.github.thomaskioko.codegen.processor.parser.parseChildPresenterData] and consumed by
+ * [io.github.thomaskioko.codegen.processor.codegen.ChildGraphGenerator].
+ *
+ * The generator emits a `@GraphExtension(scope) interface <Presenter>ChildGraph` exposing the
+ * presenter as a property and a `@ContributesTo(parentScope) @GraphExtension.Factory` nested
+ * interface that takes a `ComponentContext` and returns the graph.
+ *
+ * @property presenterClass The presenter class the annotation was attached to.
+ * @property baseName The presenter class name with the `Presenter` suffix stripped.
+ * @property packageName Package the generated file lands in (the presenter's package plus `.di`).
+ * @property scope Graph scope (typically a marker abstract class shared by sibling child
+ *   presenters under the same host).
+ * @property parentScope Parent dependency injection scope the generated factory contributes to.
+ */
+internal data class ChildPresenterData(
+    val presenterClass: ClassName,
+    val baseName: String,
+    val packageName: String,
+    val scope: ClassName,
+    val parentScope: ClassName,
+) {
+    val graphClassName: ClassName = ClassName(packageName, "${baseName}ChildGraph")
+    val graphFactoryFunName: String = "create${baseName}Graph"
+    val graphPropertyName: String = baseName.replaceFirstChar { it.lowercaseChar() } + "Presenter"
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/UiBindingData.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/UiBindingData.kt
@@ -18,6 +18,9 @@ internal enum class UiBindingKind {
 
     /** Renderer for an overlay presenter. Pairs with `@SheetUi`. The generated binding does not forward `Modifier`. */
     Sheet,
+
+    /** Renderer for a tab-root presenter. Pairs with `@TabUi`. The generated binding downcasts to `TabChild` and forwards `Modifier`. */
+    Tab,
 }
 
 /**

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AppRootParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AppRootParser.kt
@@ -110,6 +110,7 @@ private fun inferBoundInterface(
 
     return when (candidates.size) {
         1 -> candidates.first()
+
         0 -> {
             logger.error(
                 "@${Constants.APP_ROOT} requires the implementation to extend exactly one " +
@@ -118,6 +119,7 @@ private fun inferBoundInterface(
             )
             null
         }
+
         else -> {
             val names = candidates.joinToString(", ") { it.simpleName }
             logger.error(

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AppRootParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AppRootParser.kt
@@ -1,0 +1,132 @@
+package io.github.thomaskioko.codegen.processor.parser
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.ksp.toClassName
+import io.github.thomaskioko.codegen.processor.Constants
+import io.github.thomaskioko.codegen.processor.data.AppRootData
+
+/**
+ * Parses an `@AppRoot` annotation on an `@AssistedInject` presenter implementation into the
+ * [AppRootData] the [io.github.thomaskioko.codegen.processor.codegen.AppRootBindingGenerator]
+ * consumes.
+ *
+ * The parser infers the bound interface from the implementation's supertypes by picking the
+ * first non-marker interface. Decompose's `ComponentContext` (used as a delegate) is filtered
+ * out. The nested `@AssistedFactory` interface is located, and its single factory function is
+ * captured for the generated `@Provides` body.
+ *
+ * ## Errors
+ *
+ * Returns `null` and logs a compile error pinned to the implementation when:
+ *
+ * - The class does not carry `@AssistedInject`.
+ * - The class does not declare a nested `@AssistedFactory` interface.
+ * - The nested factory does not declare exactly one function.
+ * - The class extends zero or more than one non-marker interface.
+ *
+ * @param presenter The class declaration the annotation is attached to.
+ * @param logger KSP's diagnostic sink. Used to report validation errors.
+ * @return The structured representation of the annotation, or `null` if validation failed.
+ */
+internal fun parseAppRootData(
+    presenter: KSClassDeclaration,
+    logger: KSPLogger,
+): AppRootData? {
+    val annotation = presenter.findAnnotation(Constants.APP_ROOT_FQN) ?: return null
+    val parentScope = annotation.classArgument("parentScope")
+
+    if (!presenter.hasAnnotation(Constants.ASSISTED_INJECT_FQN)) {
+        logger.error(
+            "@${Constants.APP_ROOT} requires @AssistedInject on the implementation class",
+            presenter,
+        )
+        return null
+    }
+
+    val factory = presenter.findNestedAssistedFactory() ?: run {
+        logger.error(
+            "@${Constants.APP_ROOT} requires a nested @AssistedFactory interface on the " +
+                "implementation class",
+            presenter,
+        )
+        return null
+    }
+
+    val factoryFunction = factory.declarations
+        .filterIsInstance<com.google.devtools.ksp.symbol.KSFunctionDeclaration>()
+        .filter { it.simpleName.asString() != "<init>" }
+        .toList()
+    if (factoryFunction.size != 1) {
+        logger.error(
+            "@${Constants.APP_ROOT} requires the nested @AssistedFactory to declare exactly one " +
+                "function (found ${factoryFunction.size})",
+            factory,
+        )
+        return null
+    }
+
+    val boundInterface = inferBoundInterface(presenter, logger) ?: return null
+
+    val pkg = presenter.packageName.asString()
+    return AppRootData(
+        implClassName = presenter.toClassName(),
+        interfaceClassName = boundInterface,
+        factoryClassName = factory.toClassName(),
+        factoryFunctionName = factoryFunction.first().simpleName.asString(),
+        parentScope = parentScope,
+        packageName = if (pkg.isEmpty()) "di" else "$pkg.di",
+    )
+}
+
+/**
+ * Picks the bound interface for an `@AppRoot` implementation from its declared supertypes.
+ *
+ * Walks the resolved supertypes in declaration order, skips Kotlin's implicit `kotlin.Any`,
+ * skips Decompose's `ComponentContext` (which is commonly used as a delegate via
+ * `ComponentContext by componentContext`), and returns the first remaining interface. If there
+ * is more than one such interface or none at all, the function logs a compile error and returns
+ * `null`.
+ *
+ * @param presenter The annotated implementation class.
+ * @param logger KSP's diagnostic sink. Used to report validation errors.
+ * @return The bound interface as a KotlinPoet [ClassName], or `null` if validation failed.
+ */
+private fun inferBoundInterface(
+    presenter: KSClassDeclaration,
+    logger: KSPLogger,
+): ClassName? {
+    val candidates = presenter.superTypes
+        .mapNotNull { reference ->
+            val declaration = reference.resolve().declaration as? KSClassDeclaration ?: return@mapNotNull null
+            val qualifiedName = declaration.qualifiedName?.asString() ?: return@mapNotNull null
+            if (qualifiedName == "kotlin.Any") return@mapNotNull null
+            if (qualifiedName == "com.arkivanov.decompose.ComponentContext") return@mapNotNull null
+            if (declaration.classKind != com.google.devtools.ksp.symbol.ClassKind.INTERFACE) return@mapNotNull null
+            declaration.toClassName()
+        }
+        .toList()
+
+    return when (candidates.size) {
+        1 -> candidates.first()
+        0 -> {
+            logger.error(
+                "@${Constants.APP_ROOT} requires the implementation to extend exactly one " +
+                    "interface (found 0). Declare the bound presenter interface and implement it.",
+                presenter,
+            )
+            null
+        }
+        else -> {
+            val names = candidates.joinToString(", ") { it.simpleName }
+            logger.error(
+                "@${Constants.APP_ROOT} requires the implementation to extend exactly one " +
+                    "interface (found ${candidates.size}: $names). The processor cannot infer " +
+                    "which one is the bound presenter interface.",
+                presenter,
+            )
+            null
+        }
+    }
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AppRootUiParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AppRootUiParser.kt
@@ -1,0 +1,96 @@
+package io.github.thomaskioko.codegen.processor.parser
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import io.github.thomaskioko.codegen.processor.Constants
+import io.github.thomaskioko.codegen.processor.data.AppRootUiData
+import io.github.thomaskioko.codegen.processor.data.AppRootUiParameter
+
+/**
+ * Parses an `@AppRootUi` annotation on a composable function into the [AppRootUiData] the
+ * [io.github.thomaskioko.codegen.processor.codegen.AppRootUiBindingGenerator] consumes.
+ *
+ * The parser reads the composable's parameters in declaration order, skips a final
+ * `modifier: Modifier` parameter (recording its presence on [AppRootUiData.hasModifier]), and
+ * captures every other parameter as an [AppRootUiParameter]. The generator turns those entries
+ * into properties on the generated `AppRootProvider` interface and uses the same names to call
+ * the composable inside the generated extension.
+ *
+ * ## Errors
+ *
+ * Returns `null` and logs a compile error pinned to the function when:
+ *
+ * - The function lives in the default (empty) package.
+ * - The function has no non-modifier parameters.
+ * - The first non-modifier parameter type does not equal the annotation's `presenter` argument.
+ *
+ * @param function The composable function the annotation is attached to.
+ * @param logger KSP's diagnostic sink. Used to report validation errors.
+ * @return The structured representation of the annotation, or `null` if validation failed.
+ */
+internal fun parseAppRootUiData(
+    function: KSFunctionDeclaration,
+    logger: KSPLogger,
+): AppRootUiData? {
+    val annotation = function.annotations.firstOrNull { ann ->
+        ann.annotationType.resolve().declaration.qualifiedName?.asString() == Constants.APP_ROOT_UI_FQN
+    } ?: return null
+
+    val pkg = function.packageName.asString()
+    if (pkg.isEmpty()) {
+        logger.error(
+            "@${Constants.APP_ROOT_UI} cannot be applied to top-level functions in the default package",
+            function,
+        )
+        return null
+    }
+
+    val presenterClass = annotation.classArgument("presenter")
+    val parentScope = annotation.classArgument("parentScope")
+
+    val allParameters = function.parameters
+    val modifierParam = allParameters.lastOrNull { param ->
+        val typeName = param.type.resolve().declaration.qualifiedName?.asString()
+        param.name?.asString() == "modifier" && typeName == "androidx.compose.ui.Modifier"
+    }
+    val nonModifierParams = allParameters.filterNot { it === modifierParam }
+
+    if (nonModifierParams.isEmpty()) {
+        logger.error(
+            "@${Constants.APP_ROOT_UI} requires the composable to declare at least one " +
+                "non-modifier parameter for the root presenter",
+            function,
+        )
+        return null
+    }
+
+    val firstParamTypeName = nonModifierParams.first().type.resolve().toTypeName()
+    val expected = presenterClass.canonicalName
+    val actual = firstParamTypeName.toString()
+    if (actual != expected) {
+        logger.error(
+            "@${Constants.APP_ROOT_UI} first parameter type ($actual) does not match the " +
+                "declared presenter type ($expected)",
+            function,
+        )
+        return null
+    }
+
+    val parameters = nonModifierParams.map { param ->
+        AppRootUiParameter(
+            name = param.name?.asString()
+                ?: error("Could not determine parameter name on @${Constants.APP_ROOT_UI} composable"),
+            type = param.type.resolve().toTypeName(),
+        )
+    }
+
+    return AppRootUiData(
+        composableFunction = MemberName(pkg, function.simpleName.asString()),
+        packageName = pkg,
+        parameters = parameters,
+        hasModifier = modifierParam != null,
+        parentScope = parentScope,
+    )
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/ChildPresenterParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/ChildPresenterParser.kt
@@ -1,0 +1,34 @@
+package io.github.thomaskioko.codegen.processor.parser
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.ksp.toClassName
+import io.github.thomaskioko.codegen.processor.Constants
+import io.github.thomaskioko.codegen.processor.data.ChildPresenterData
+
+/**
+ * Parses a `@ChildPresenter` annotation on a presenter class into [ChildPresenterData].
+ *
+ * @param presenter The annotated class.
+ * @param logger KSP's diagnostic sink. Used to report validation errors.
+ * @return The structured representation of the annotation, or `null` if validation failed.
+ */
+internal fun parseChildPresenterData(
+    presenter: KSClassDeclaration,
+    logger: KSPLogger,
+): ChildPresenterData? {
+    val annotation = presenter.findAnnotation(Constants.CHILD_PRESENTER_FQN) ?: return null
+    val scope = annotation.classArgument("scope")
+    val parentScope = annotation.classArgument("parentScope")
+
+    val pkg = presenter.packageName.asString()
+    val baseName = presenter.simpleName.asString().removeSuffix("Presenter")
+
+    return ChildPresenterData(
+        presenterClass = presenter.toClassName(),
+        baseName = baseName,
+        packageName = if (pkg.isEmpty()) "di" else "$pkg.di",
+        scope = scope,
+        parentScope = parentScope,
+    )
+}

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/UiParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/UiParser.kt
@@ -40,6 +40,7 @@ internal fun parseUiBindingData(
     val (fqn, shortName) = when (kind) {
         UiBindingKind.Screen -> Constants.SCREEN_UI_FQN to Constants.SCREEN_UI
         UiBindingKind.Sheet -> Constants.SHEET_UI_FQN to Constants.SHEET_UI
+        UiBindingKind.Tab -> Constants.TAB_UI_FQN to Constants.TAB_UI
     }
     val annotation = function.annotations.firstOrNull { ann ->
         ann.annotationType.resolve().declaration.qualifiedName?.asString() == fqn

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/External.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/External.kt
@@ -30,6 +30,7 @@ internal val GraphExtension: ClassName = ClassName(METRO_PACKAGE, "GraphExtensio
 internal val Provides: ClassName = ClassName(METRO_PACKAGE, "Provides")
 internal val IntoSet: ClassName = ClassName(METRO_PACKAGE, "IntoSet")
 internal val BindingContainer: ClassName = ClassName(METRO_PACKAGE, "BindingContainer")
+internal val SingleIn: ClassName = ClassName(METRO_PACKAGE, "SingleIn")
 
 // Consumer navigation primitives: route supertypes (NavRoute, NavRoot, BaseRoute), the
 // NavDestination sealed family the bindings contribute to, the route binding multibinding
@@ -51,9 +52,13 @@ internal const val NAVIGATION_UI_PACKAGE: String = "com.thomaskioko.tvmaniac.nav
 internal val ScreenContent: ClassName = ClassName(NAVIGATION_UI_PACKAGE, "ScreenContent")
 internal val SheetContent: ClassName = ClassName(NAVIGATION_UI_PACKAGE, "SheetContent")
 
-// Compose: only UiBindingGenerator references Modifier, and only on the screen path. Overlay
-// renderers do not forward a modifier.
+// Compose: only UiBindingGenerator references Modifier indirectly (through the consumer's
+// ScreenContent lambda type). AppRootUiBindingGenerator emits the @Composable annotation and
+// the Modifier parameter directly, so it references both ClassName constants below.
 internal const val COMPOSE_UI_PACKAGE: String = "androidx.compose.ui"
+internal const val COMPOSE_RUNTIME_PACKAGE: String = "androidx.compose.runtime"
+internal val Composable: ClassName = ClassName(COMPOSE_RUNTIME_PACKAGE, "Composable")
+internal val Modifier: ClassName = ClassName(COMPOSE_UI_PACKAGE, "Modifier")
 
 // Consumer home navigation: TabChild is the wrapper the tab root factory lambda always wraps its
 // produced presenter in.

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/KotlinPoet.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/KotlinPoet.kt
@@ -30,6 +30,17 @@ internal fun bindingContainer(): AnnotationSpec =
     AnnotationSpec.builder(BindingContainer).build()
 
 /**
+ * Builds the `@SingleIn([scope]::class)` annotation that scopes a `@Provides` function to the
+ * lifetime of the given dependency injection scope.
+ *
+ * @param scope The scope the bound instance lives in.
+ */
+internal fun singleIn(scope: ClassName): AnnotationSpec =
+    AnnotationSpec.builder(SingleIn)
+        .addMember("%T::class", scope)
+        .build()
+
+/**
  * Builds the `@GraphExtension([scope]::class)` annotation that every generated graph interface
  * carries. This is the Metro annotation that declares a graph fragment scoped to the given type.
  *

--- a/gradle/publishing.properties
+++ b/gradle/publishing.properties
@@ -2,7 +2,7 @@
 # Composite-specific overrides (POM_NAME, POM_DESCRIPTION) stay in each
 # composite's own gradle.properties.
 GROUP=io.github.thomaskioko.gradle.plugins
-VERSION_NAME=0.7.6
+VERSION_NAME=0.7.7
 INCEPTION_YEAR=2025
 
 POM_REPO_NAME=app-gradle-plugins

--- a/lint-rules/README.md
+++ b/lint-rules/README.md
@@ -2,10 +2,11 @@
 
 A small ktlint rule set that enforces project specific conventions for the codebase. This is loaded into
 Spotless through the lint convention plugin in `plugins/`.
-Six rules cover:
+Eight rules cover:
 - Navigation layering
 - Compose preview styling
 - Metro Dependency injection cleanup
+- Codegen annotation discipline (presenter and Compose screen)
 - Test naming
 
 ## Rules
@@ -98,6 +99,65 @@ class FooImpl : Foo
 
 The fix is autocorrect-able. The rule covers both class-level `@Inject` and primary-constructor-level `@Inject` (`@Inject constructor(...)`); either is removed when a `@Contributes...` annotation is present on the class.
 
+### `tvmaniac:presenter-needs-codegen-annotation`
+
+Requires every Metro injected presenter class to also carry a codegen annotation that wires it into the navigation system. The rule fires on a top level class whose simple name ends with `Presenter`, that is annotated with `@Inject` or `@AssistedInject`, and that is missing every accepted codegen annotation (`@NavDestination`, `@AppRoot`).
+
+```kotlin
+// Forbidden:
+@Inject
+class TrendingShowsPresenter(...)
+
+// Allowed:
+@Inject
+@NavDestination(
+    route = TrendingShowsRoute::class,
+    parentScope = ActivityScope::class,
+    kind = DestinationKind.SCREEN,
+)
+class TrendingShowsPresenter(...)
+
+// Allowed (root presenter):
+@AppRoot(parentScope = ActivityScope::class)
+@AssistedInject
+class DefaultRootPresenter(...) : RootPresenter
+```
+
+Classes annotated with `@ContributesBinding`, `@ContributesIntoSet`, or `@ContributesIntoMap` are exempt because Metro wires them through the binding rather than through codegen. Abstract and interface presenters are exempt for the same reason. Child presenters that are exposed through a manual `@GraphExtension` opt out by listing their simple class name in `ktlint_tvmaniac_unrouted_presenters`. See [Configuring codegen exemptions](#configuring-codegen-exemptions).
+
+### `tvmaniac:compose-screen-needs-codegen-annotation`
+
+Requires every Compose function that takes a presenter parameter to carry a codegen UI annotation that wires it into the navigation host's renderer multibinding. The rule fires on a top level `@Composable` function that declares a parameter named `presenter` or `rootPresenter` and is missing every accepted codegen UI annotation (`@ScreenUi`, `@SheetUi`, `@AppRootUi`).
+
+```kotlin
+// Forbidden:
+@Composable
+fun TrendingShowsScreen(
+    presenter: TrendingShowsPresenter,
+    modifier: Modifier = Modifier,
+) { ... }
+
+// Allowed:
+@ScreenUi(presenter = TrendingShowsPresenter::class, parentScope = ActivityScope::class)
+@Composable
+fun TrendingShowsScreen(
+    presenter: TrendingShowsPresenter,
+    modifier: Modifier = Modifier,
+) { ... }
+
+// Allowed (host composable):
+@AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)
+@Composable
+fun RootScreen(
+    rootPresenter: RootPresenter,
+    screenContents: Set<ScreenContent>,
+    sheetContents: Set<SheetContent>,
+    modifier: Modifier = Modifier,
+) { ... }
+```
+
+Tab root screens dispatched manually inside a parent host opt out by listing their simple function name in `ktlint_tvmaniac_unrouted_screens`. See [Configuring codegen exemptions](#configuring-codegen-exemptions).
+
 ### `tvmaniac:test-name-format`
 
 Enforces the BDD style `should X given Y` (or `should X when Y`) test naming convention. Both backticked and camelCase forms are accepted; camelCase is needed for `src/androidTest/` because DEX format 037 forbids spaces in identifiers.
@@ -113,6 +173,35 @@ Enforces the BDD style `should X given Y` (or `should X when Y`) test naming con
 ```
 
 The rule covers `@Test`, `@ParameterizedTest`, and `@RepeatedTest`. Lifecycle annotations (`@BeforeTest`, `@AfterEach`, etc.) are ignored because they are setup and teardown hooks, not tests.
+
+## Configuring codegen exemptions
+
+The `tvmaniac:presenter-needs-codegen-annotation` and `tvmaniac:compose-screen-needs-codegen-annotation` rules each read one `.editorconfig` property listing the names that opt out of the requirement.
+
+### `ktlint_tvmaniac_unrouted_presenters`
+
+Comma separated simple class names of presenters that are intentionally not wired through codegen. Useful for child presenters exposed through a manual `@GraphExtension` (for example pager children inside a parent presenter).
+
+```
+[*.{kt,kts}]
+ktlint_tvmaniac_unrouted_presenters = UpNextPresenter, CalendarPresenter
+```
+
+- **Default**: empty. Every Metro injected `Presenter` class must carry `@NavDestination` or `@AppRoot`.
+- **Whitespace** around entries is trimmed; **blank entries** are ignored.
+- Setting the property to `unset` (or leaving the value empty) keeps the default empty list.
+
+### `ktlint_tvmaniac_unrouted_screens`
+
+Comma separated simple function names of Compose screens that are dispatched manually inside a parent host (for example tab root screens invoked from the home host's `Children` block).
+
+```
+[*.{kt,kts}]
+ktlint_tvmaniac_unrouted_screens = DiscoverScreen, LibraryScreen, ProfileScreen, ProgressScreen
+```
+
+- **Default**: empty. Every `@Composable` function with a presenter parameter must carry `@ScreenUi`, `@SheetUi`, or `@AppRootUi`.
+- Whitespace and blank entry handling matches `ktlint_tvmaniac_unrouted_presenters`.
 
 ## Configuring the navigation layer
 

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.dependency.analysis)
     alias(libs.plugins.publish)
+    alias(libs.plugins.spotless)
 }
 
 base {

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/TvManiacRuleSetProvider.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/TvManiacRuleSetProvider.kt
@@ -3,6 +3,8 @@ package io.github.thomaskioko.gradle.plugins.lint
 import com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
 import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
 import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
+import io.github.thomaskioko.gradle.plugins.lint.codegen.ComposeScreenCodegenAnnotationRule
+import io.github.thomaskioko.gradle.plugins.lint.codegen.PresenterCodegenAnnotationRule
 import io.github.thomaskioko.gradle.plugins.lint.metro.MetroRedundantInjectRule
 import io.github.thomaskioko.gradle.plugins.lint.navigation.NoCustomNavigatorInterfaceRule
 import io.github.thomaskioko.gradle.plugins.lint.navigation.NoMutatingRouterImportRule
@@ -29,6 +31,13 @@ import io.github.thomaskioko.gradle.plugins.lint.tests.TestNameFormatRule
  *   styling wrappers inside `@Preview` composables (configurable via `.editorconfig`).
  * - [MetroRedundantInjectRule] (`tvmaniac:metro-redundant-inject`) removes redundant `@Inject`
  *   on classes that already declare a Metro `@Contributes...` annotation.
+ * - [PresenterCodegenAnnotationRule] (`tvmaniac:presenter-needs-codegen-annotation`) requires
+ *   every Metro-injected `Presenter` class to carry `@NavDestination` or `@AppRoot` so the
+ *   codegen processor wires it into the navigation graph.
+ * - [ComposeScreenCodegenAnnotationRule] (`tvmaniac:compose-screen-needs-codegen-annotation`)
+ *   requires every `@Composable` function with a presenter parameter to carry `@ScreenUi`,
+ *   `@SheetUi`, or `@AppRootUi` so the codegen processor wires it into the renderer
+ *   multibinding.
  * - [TestNameFormatRule] (`tvmaniac:test-name-format`) enforces the `should X given Y` test
  *   naming convention.
  *
@@ -43,7 +52,8 @@ public class TvManiacRuleSetProvider : RuleSetProviderV3(RuleSetId(RULE_SET_ID))
         RuleProvider { NoCustomNavigatorInterfaceRule() },
         RuleProvider { NoStyleWrapperInPreviewRule() },
         RuleProvider { MetroRedundantInjectRule() },
-        RuleProvider { TestNameFormatRule() },
+        RuleProvider { PresenterCodegenAnnotationRule() },
+        RuleProvider { ComposeScreenCodegenAnnotationRule() },
     )
 
     private companion object {

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/CodegenExemptions.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/CodegenExemptions.kt
@@ -1,0 +1,61 @@
+package io.github.thomaskioko.gradle.plugins.lint.codegen
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CommaSeparatedListValueParser
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import org.ec4j.core.model.PropertyType
+
+/**
+ * `.editorconfig` property identifying presenter classes that intentionally do not carry a
+ * navigation codegen annotation.
+ *
+ * Property key: `ktlint_tvmaniac_unrouted_presenters`. Default: empty. Comma-separated list of
+ * simple class names. Each entry is matched against the annotated class's `simpleName`. Use this
+ * list for child presenters that are exposed through a manual `@GraphExtension` rather than
+ * routed by the codegen system, for example tab-internal sub-presenters or pager children.
+ *
+ * ## Example
+ *
+ * ```
+ * [*.{kt,kts}]
+ * ktlint_tvmaniac_unrouted_presenters = UpNextPresenter, CalendarPresenter
+ * ```
+ */
+internal val UNROUTED_PRESENTERS_PROPERTY: EditorConfigProperty<Set<String>> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "ktlint_tvmaniac_unrouted_presenters",
+            "Comma-separated simple class names for presenters that opt out of the codegen annotation requirement.",
+            CommaSeparatedListValueParser(),
+            emptySet<String>(),
+        ),
+        defaultValue = emptySet(),
+        propertyWriter = { value -> value.joinToString(",") },
+    )
+
+/**
+ * `.editorconfig` property identifying Compose screens that intentionally do not carry a
+ * navigation codegen UI annotation.
+ *
+ * Property key: `ktlint_tvmaniac_unrouted_screens`. Default: empty. Comma-separated list of
+ * simple function names. Use this list for screens dispatched manually inside a parent host
+ * (typically tab-root screens invoked from the home host's `Children` block) rather than
+ * resolved through `Set<ScreenContent>`.
+ *
+ * ## Example
+ *
+ * ```
+ * [*.{kt,kts}]
+ * ktlint_tvmaniac_unrouted_screens = DiscoverScreen, LibraryScreen, ProfileScreen, ProgressScreen
+ * ```
+ */
+internal val UNROUTED_SCREENS_PROPERTY: EditorConfigProperty<Set<String>> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "ktlint_tvmaniac_unrouted_screens",
+            "Comma-separated simple function names for Compose screens that opt out of the codegen UI annotation requirement.",
+            CommaSeparatedListValueParser(),
+            emptySet<String>(),
+        ),
+        defaultValue = emptySet(),
+        propertyWriter = { value -> value.joinToString(",") },
+    )

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/ComposeScreenCodegenAnnotationRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/ComposeScreenCodegenAnnotationRule.kt
@@ -1,0 +1,115 @@
+package io.github.thomaskioko.gradle.plugins.lint.codegen
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleAutocorrectApproveHandler
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import io.github.thomaskioko.gradle.plugins.lint.RULE_ABOUT
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+/**
+ * Requires every Compose function that takes a presenter parameter to carry a codegen UI
+ * annotation that wires it into the navigation host's renderer multibinding.
+ *
+ * The rule fires on a top-level `@Composable` function that declares a parameter named
+ * `presenter` or `rootPresenter` and is missing every accepted codegen UI annotation
+ * (`@ScreenUi`, `@SheetUi`, `@AppRootUi`). Without one of those annotations the navigation host
+ * cannot dispatch the composable through `Set<ScreenContent>`, `Set<SheetContent>`, or the
+ * generated `AppRootProvider`, so the composable is unreachable.
+ *
+ * Tab-root screens dispatched manually inside a parent host (for example the screens invoked
+ * from the home host's `Children` block) opt out by listing their simple function name in
+ * `ktlint_tvmaniac_unrouted_screens` in the project `.editorconfig`.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * // Forbidden:
+ * @Composable
+ * fun TrendingShowsScreen(
+ *     presenter: TrendingShowsPresenter,
+ *     modifier: Modifier = Modifier,
+ * ) { ... }
+ *
+ * // Allowed:
+ * @ScreenUi(presenter = TrendingShowsPresenter::class, parentScope = ActivityScope::class)
+ * @Composable
+ * fun TrendingShowsScreen(
+ *     presenter: TrendingShowsPresenter,
+ *     modifier: Modifier = Modifier,
+ * ) { ... }
+ *
+ * // Allowed (host composable):
+ * @AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)
+ * @Composable
+ * fun RootScreen(
+ *     rootPresenter: RootPresenter,
+ *     screenContents: Set<ScreenContent>,
+ *     sheetContents: Set<SheetContent>,
+ *     modifier: Modifier = Modifier,
+ * ) { ... }
+ * ```
+ */
+public class ComposeScreenCodegenAnnotationRule :
+    Rule(
+        ruleId = RuleId("tvmaniac:compose-screen-needs-codegen-annotation"),
+        about = RULE_ABOUT,
+        usesEditorConfigProperties = setOf(UNROUTED_SCREENS_PROPERTY),
+    ),
+    RuleAutocorrectApproveHandler {
+    private var unroutedScreens: Set<String> = UNROUTED_SCREENS_PROPERTY.defaultValue
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        unroutedScreens = editorConfig[UNROUTED_SCREENS_PROPERTY]
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        if (node.elementType != FUN) return
+
+        val function = node.psi as? KtNamedFunction ?: return
+        if (!function.isTopLevel) return
+
+        val name = function.name ?: return
+        if (name in unroutedScreens) return
+
+        val annotationNames = function.annotationEntries
+            .mapNotNullTo(mutableSetOf()) { it.shortName?.asString() }
+        if (COMPOSABLE_ANNOTATION !in annotationNames) return
+        if (!function.hasPresenterParameter()) return
+        if (UI_CODEGEN_ANNOTATIONS.any { it in annotationNames }) return
+
+        emit(node.startOffset, errorMessage(name), false)
+    }
+
+    private fun KtNamedFunction.hasPresenterParameter(): Boolean =
+        valueParameters.any { it.name in PRESENTER_PARAMETER_NAMES }
+
+    public companion object {
+        internal const val COMPOSABLE_ANNOTATION: String = "Composable"
+
+        internal val PRESENTER_PARAMETER_NAMES: Set<String> = setOf(
+            "presenter",
+            "rootPresenter",
+        )
+
+        internal val UI_CODEGEN_ANNOTATIONS: Set<String> = setOf(
+            "ScreenUi",
+            "SheetUi",
+            "AppRootUi",
+        )
+
+        internal fun errorMessage(functionName: String): String =
+            "$functionName is a @Composable function that accepts a presenter parameter, but is " +
+                "missing a codegen UI annotation. Add @ScreenUi(...) for a stack screen, @SheetUi(...) " +
+                "for a modal overlay, or @AppRootUi(...) for the application's host composable. If the " +
+                "screen is dispatched manually inside a parent host (for example a tab-root screen " +
+                "invoked from a `Children` block), add its simple name to " +
+                "`ktlint_tvmaniac_unrouted_screens` in `.editorconfig`."
+    }
+}

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/PresenterCodegenAnnotationRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/PresenterCodegenAnnotationRule.kt
@@ -1,0 +1,118 @@
+package io.github.thomaskioko.gradle.plugins.lint.codegen
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.CLASS
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleAutocorrectApproveHandler
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import io.github.thomaskioko.gradle.plugins.lint.RULE_ABOUT
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.lexer.KtTokens
+
+/**
+ * Requires every presenter class injected by Metro to also carry a codegen annotation that wires
+ * it into the navigation system.
+ *
+ * The rule fires on a top-level class whose simple name ends with `Presenter`, that is annotated
+ * with `@Inject` or `@AssistedInject`, and that is missing every accepted codegen annotation
+ * (`@NavDestination`, `@AppRoot`). Without one of those annotations the consumer has to write
+ * the matching `@GraphExtension` and binding container by hand, defeating the codegen.
+ *
+ * Classes annotated with `@ContributesBinding` are exempt because Metro wires them through the
+ * binding rather than through codegen. Abstract and interface presenters are exempt for the same
+ * reason. Child presenters that are exposed through a manual `@GraphExtension` (for example
+ * pager children inside a parent presenter) opt out by listing their simple class name in
+ * `ktlint_tvmaniac_unrouted_presenters` in the project `.editorconfig`.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * // Forbidden:
+ * @Inject
+ * class TrendingShowsPresenter(...)
+ *
+ * // Allowed:
+ * @Inject
+ * @NavDestination(
+ *     route = TrendingShowsRoute::class,
+ *     parentScope = ActivityScope::class,
+ *     kind = DestinationKind.SCREEN,
+ * )
+ * class TrendingShowsPresenter(...)
+ *
+ * // Allowed (root presenter):
+ * @AppRoot(parentScope = ActivityScope::class)
+ * @AssistedInject
+ * class DefaultRootPresenter(...) : RootPresenter
+ *
+ * // Allowed (child presenter on the project's exemption list):
+ * @Inject
+ * class UpNextPresenter(...)
+ * ```
+ */
+public class PresenterCodegenAnnotationRule :
+    Rule(
+        ruleId = RuleId("tvmaniac:presenter-needs-codegen-annotation"),
+        about = RULE_ABOUT,
+        usesEditorConfigProperties = setOf(UNROUTED_PRESENTERS_PROPERTY),
+    ),
+    RuleAutocorrectApproveHandler {
+    private var unroutedPresenters: Set<String> = UNROUTED_PRESENTERS_PROPERTY.defaultValue
+
+    override fun beforeFirstNode(editorConfig: EditorConfig) {
+        unroutedPresenters = editorConfig[UNROUTED_PRESENTERS_PROPERTY]
+    }
+
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        if (node.elementType != CLASS) return
+
+        val ktClass = node.psi as? KtClass ?: return
+        val name = ktClass.name ?: return
+        if (!name.endsWith("Presenter")) return
+        if (ktClass.isInterface()) return
+        if (ktClass.hasModifier(KtTokens.ABSTRACT_KEYWORD)) return
+        if (name in unroutedPresenters) return
+
+        val annotationNames = ktClass.annotationEntries
+            .mapNotNullTo(mutableSetOf()) { it.shortName?.asString() }
+        val hasInjection = INJECTION_ANNOTATIONS.any { it in annotationNames }
+        if (!hasInjection) return
+
+        if (BINDING_OPT_OUT_ANNOTATIONS.any { it in annotationNames }) return
+        if (CODEGEN_ANNOTATIONS.any { it in annotationNames }) return
+
+        emit(node.startOffset, errorMessage(name), false)
+    }
+
+    public companion object {
+        internal val INJECTION_ANNOTATIONS: Set<String> = setOf(
+            "Inject",
+            "AssistedInject",
+        )
+
+        internal val CODEGEN_ANNOTATIONS: Set<String> = setOf(
+            "NavDestination",
+            "NavDestinationAnno",
+            "AppRoot",
+            "ChildPresenter",
+        )
+
+        internal val BINDING_OPT_OUT_ANNOTATIONS: Set<String> = setOf(
+            "ContributesBinding",
+            "ContributesIntoSet",
+            "ContributesIntoMap",
+        )
+
+        internal fun errorMessage(className: String): String =
+            "$className is annotated with @Inject (or @AssistedInject) and ends with `Presenter`, " +
+                "but is missing a codegen annotation. Add @NavDestination(...) for a routed presenter, " +
+                "or @AppRoot(...) for the application's root presenter. If the presenter is exposed " +
+                "through a manual @GraphExtension (a child or pager presenter), add its simple name to " +
+                "`ktlint_tvmaniac_unrouted_presenters` in `.editorconfig`."
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/ComposeScreenCodegenAnnotationRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/ComposeScreenCodegenAnnotationRuleTest.kt
@@ -1,0 +1,180 @@
+package io.github.thomaskioko.gradle.plugins.lint.codegen
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import org.junit.jupiter.api.Test
+
+class ComposeScreenCodegenAnnotationRuleTest {
+    private val assertThat = assertThatRule { ComposeScreenCodegenAnnotationRule() }
+
+    @Test
+    fun `flags Composable with presenter parameter without codegen annotation`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Composable
+            fun TrendingShowsScreen(
+                presenter: TrendingShowsPresenter,
+                modifier: Modifier = Modifier,
+            ) {
+            }
+            """.trimIndent(),
+        ).hasLintViolationWithoutAutoCorrect(
+            line = 3,
+            col = 1,
+            detail = ComposeScreenCodegenAnnotationRule.errorMessage("TrendingShowsScreen"),
+        )
+    }
+
+    @Test
+    fun `does not flag Composable with ScreenUi annotation`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @ScreenUi(presenter = TrendingShowsPresenter::class, parentScope = ActivityScope::class)
+            @Composable
+            fun TrendingShowsScreen(
+                presenter: TrendingShowsPresenter,
+                modifier: Modifier = Modifier,
+            ) {
+            }
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag Composable with SheetUi annotation`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @SheetUi(presenter = EpisodeSheetPresenter::class, parentScope = ActivityScope::class)
+            @Composable
+            fun EpisodeSheet(
+                presenter: EpisodeSheetPresenter,
+                modifier: Modifier = Modifier,
+            ) {
+            }
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag Composable with AppRootUi annotation`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @AppRootUi(presenter = RootPresenter::class, parentScope = ActivityScope::class)
+            @Composable
+            fun RootScreen(
+                rootPresenter: RootPresenter,
+                screenContents: Set<ScreenContent>,
+                sheetContents: Set<SheetContent>,
+                modifier: Modifier = Modifier,
+            ) {
+            }
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag Composable without presenter parameter`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Composable
+            fun GreetingCard(
+                title: String,
+                modifier: Modifier = Modifier,
+            ) {
+            }
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag function without Composable annotation`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            fun setupPresenter(
+                presenter: SomePresenter,
+            ) {
+            }
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag Composable function listed in unrouted_screens`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Composable
+            fun DiscoverScreen(
+                presenter: DiscoverShowsPresenter,
+                modifier: Modifier = Modifier,
+            ) {
+            }
+            """.trimIndent(),
+        )
+            .withEditorConfigOverride(UNROUTED_SCREENS_PROPERTY to "DiscoverScreen")
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `flags Composable host that uses rootPresenter parameter name`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Composable
+            fun RootScreen(
+                rootPresenter: RootPresenter,
+                modifier: Modifier = Modifier,
+            ) {
+            }
+            """.trimIndent(),
+        ).hasLintViolationWithoutAutoCorrect(
+            line = 3,
+            col = 1,
+            detail = ComposeScreenCodegenAnnotationRule.errorMessage("RootScreen"),
+        )
+    }
+
+    @Test
+    fun `does not flag nested Composable inside another function`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Composable
+            @ScreenUi(presenter = HomePresenter::class, parentScope = ActivityScope::class)
+            fun HomeScreen(
+                presenter: HomePresenter,
+                modifier: Modifier = Modifier,
+            ) {
+                @Composable
+                fun nested(
+                    presenter: HomePresenter,
+                ) {
+                }
+            }
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/PresenterCodegenAnnotationRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/PresenterCodegenAnnotationRuleTest.kt
@@ -1,0 +1,193 @@
+package io.github.thomaskioko.gradle.plugins.lint.codegen
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import org.junit.jupiter.api.Test
+
+class PresenterCodegenAnnotationRuleTest {
+    private val assertThat = assertThatRule { PresenterCodegenAnnotationRule() }
+
+    @Test
+    fun `flags Inject presenter without codegen annotation`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Inject
+            class TrendingShowsPresenter(
+                componentContext: ComponentContext,
+            )
+            """.trimIndent(),
+        ).hasLintViolationWithoutAutoCorrect(
+            line = 3,
+            col = 1,
+            detail = PresenterCodegenAnnotationRule.errorMessage("TrendingShowsPresenter"),
+        )
+    }
+
+    @Test
+    fun `flags AssistedInject presenter without codegen annotation`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @AssistedInject
+            class ShowDetailsPresenter(
+                componentContext: ComponentContext,
+            )
+            """.trimIndent(),
+        ).hasLintViolationWithoutAutoCorrect(
+            line = 3,
+            col = 1,
+            detail = PresenterCodegenAnnotationRule.errorMessage("ShowDetailsPresenter"),
+        )
+    }
+
+    @Test
+    fun `does not flag Inject presenter with NavDestination`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Inject
+            @NavDestination(
+                route = TrendingShowsRoute::class,
+                parentScope = ActivityScope::class,
+                kind = DestinationKind.SCREEN,
+            )
+            class TrendingShowsPresenter(
+                componentContext: ComponentContext,
+            )
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag presenter with NavDestinationAnno alias`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @NavDestinationAnno(
+                route = HomeRoute::class,
+                parentScope = ActivityScope::class,
+                kind = DestinationKind.SCREEN,
+            )
+            @Inject
+            class HomePresenter(
+                componentContext: ComponentContext,
+            )
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag AssistedInject presenter with AppRoot`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @AppRoot(parentScope = ActivityScope::class)
+            @AssistedInject
+            class DefaultRootPresenter(
+                @Assisted componentContext: ComponentContext,
+            ) : RootPresenter
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag presenter with ContributesBinding`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @ContributesBinding(AppScope::class)
+            @Inject
+            class DefaultLogoutPresenter(
+                componentContext: ComponentContext,
+            ) : LogoutPresenter
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag presenter interface`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            interface RootPresenter {
+                fun onClicked()
+            }
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag abstract presenter base class`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Inject
+            abstract class BaseFeaturePresenter(
+                componentContext: ComponentContext,
+            )
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag class without presenter suffix`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Inject
+            class TrendingShowsRepository(
+                componentContext: ComponentContext,
+            )
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag presenter without injection annotation`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            class FakeTrendingShowsPresenter(
+                componentContext: ComponentContext,
+            )
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag presenter listed in unrouted_presenters`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Inject
+            class UpNextPresenter(
+                componentContext: ComponentContext,
+            )
+            """.trimIndent(),
+        )
+            .withEditorConfigOverride(UNROUTED_PRESENTERS_PROPERTY to "UpNextPresenter")
+            .hasNoLintViolations()
+    }
+}

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.dependency.analysis)
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.publish)
+    alias(libs.plugins.spotless)
 }
 
 group = property("GROUP").toString()

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/CodegenSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/CodegenSetup.kt
@@ -1,7 +1,7 @@
 package io.github.thomaskioko.gradle.plugins.setup
 
 import io.github.thomaskioko.gradle.plugins.utils.addImplementationDependency
-import io.github.thomaskioko.gradle.plugins.utils.addKspDependencyForAllTargets
+import io.github.thomaskioko.gradle.plugins.utils.addKspDependencyForCommonMain
 import io.github.thomaskioko.gradle.plugins.utils.getDependency
 import org.gradle.api.Project
 
@@ -13,5 +13,5 @@ internal fun Project.setupCodegen() {
 
     setupKsp()
     addImplementationDependency(getDependency("codegen-annotations"))
-    addKspDependencyForAllTargets(getDependency("codegen-processor"))
+    addKspDependencyForCommonMain(getDependency("codegen-processor"))
 }

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/KspSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/KspSetup.kt
@@ -3,13 +3,55 @@ package io.github.thomaskioko.gradle.plugins.setup
 import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Project
 import org.gradle.process.CommandLineArgumentProvider
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
+/**
+ * Applies the KSP plugin and threads any caller-supplied processor arguments into [KspExtension].
+ *
+ * For Kotlin Multiplatform projects, also registers `kspCommonMainKotlinMetadata` as the canonical
+ * source of truth for code generated from `commonMain` annotations: its output directory is added
+ * to the `commonMain` Kotlin source set, and every Kotlin compilation task and per-target `ksp*`
+ * task gains an explicit dependency on it. Without this wiring the IDE flags KSP-generated symbols
+ * referenced from `commonMain` as unresolved even though Gradle compiles cleanly, and per-target
+ * compilations can race the metadata task.
+ */
 internal fun Project.setupKsp(arguments: List<CommandLineArgumentProvider> = emptyList()) {
     plugins.apply("com.google.devtools.ksp")
 
     extensions.configure(KspExtension::class.java) { extension ->
         arguments.forEach {
             extension.arg(it)
+        }
+    }
+
+    pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+        registerCommonMainKspMetadataSource()
+    }
+}
+
+/**
+ * Wires `kspCommonMainKotlinMetadata` output into the `commonMain` source set and orders every
+ * downstream task after it.
+ *
+ * Adds `build/generated/ksp/metadata/commonMain/kotlin` as a `commonMain` Kotlin source directory
+ * so the IDE indexes generated symbols alongside hand-written `commonMain` code. Configures every
+ * Kotlin compilation task and per-target `ksp*` task (except the metadata task itself) to depend on
+ * `kspCommonMainKotlinMetadata` so Gradle never reads the generated output before it is produced.
+ */
+private fun Project.registerCommonMainKspMetadataSource() {
+    val metadataDir = layout.buildDirectory.dir("generated/ksp/metadata/commonMain/kotlin")
+
+    extensions.configure(KotlinMultiplatformExtension::class.java) { kotlin ->
+        kotlin.sourceSets.named("commonMain") { sourceSet ->
+            sourceSet.kotlin.srcDir(metadataDir)
+        }
+    }
+
+    tasks.configureEach { task ->
+        if (task.name == "kspCommonMainKotlinMetadata") return@configureEach
+        if (task.name.startsWith("ksp") || task is KotlinCompilationTask<*>) {
+            task.dependsOn("kspCommonMainKotlinMetadata")
         }
     }
 }

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/DependencyExtensions.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/DependencyExtensions.kt
@@ -74,6 +74,25 @@ private fun Project.addKspDependencyForAllTargets(
     }
 }
 
+/**
+ * Registers a KSP processor that should run only against `commonMain` sources.
+ *
+ * For Kotlin Multiplatform projects, attaches [dependency] to the `kspCommonMainMetadata`
+ * configuration so the processor runs once on shared sources and downstream targets pick the
+ * generated symbols up through the `commonMain` source set wired by `setupKsp`. Single-platform
+ * projects fall back to the default `ksp` configuration.
+ *
+ * Prefer this over [addKspDependencyForAllTargets] for processors whose annotations live in
+ * `commonMain`, since attaching the same processor to per-target configurations would generate
+ * the same classes again from each target compilation and trigger redeclaration errors.
+ */
+internal fun Project.addKspDependencyForCommonMain(dependency: Provider<MinimalExternalModuleDependency>) {
+    when {
+        isKmpProject() -> dependencies.add("kspCommonMainMetadata", dependency)
+        else -> dependencies.add("ksp", dependency)
+    }
+}
+
 private fun Project.isKmpProject(): Boolean = extensions.findByType(KotlinMultiplatformExtension::class.java) != null
 
 private fun Project.addKspDependencyForKmp(


### PR DESCRIPTION
## Description
This PR adds support for `AppRoot`, `AppRootUi`, `ChildPresenter`, and `TabUi` navigation codegen annotations to streamline navigation setup. It also introduces custom ktlint rules to enforce the usage of these codegen annotations across the codebase, ensuring architectural consistency.

## Changes
- Added new navigation codegen annotations for AppRoot, AppRootUi, ChildPresenter, and TabUi.
- Implemented KSP parsers and generators for the new navigation annotations.
- Introduced custom ktlint rules to enforce codegen usage on Composables and Presenters.
- Updated documentation with detailed guides on annotations, architecture, and examples.
- Enhanced Gradle plugin setup for KSP and codegen configuration.