### PR TITLE
 Fix dependency analysis aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ See [annotations.md](codegen/docs/annotations.md), [examples.md](codegen/docs/ex
 
 - `tvmaniac:presenter-needs-codegen-annotation` now accepts `@ChildPresenter` as a satisfying annotation, so child presenters routed through the new codegen path no longer need an `editorconfig` exemption.
 
+### Fix
+- Apply `com.autonomousapps.dependency-analysis` per subproject.
+- Default `appAuthRedirectScheme` test manifest placeholder on KMP Android targets so transitive AppAuth dependencies do not break `processAndroidHostTestManifest` / `processAndroidDeviceTestManifest`.
+
 ## 0.7.7 *(2026-05-10)*
 
 ### Navigation

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BasePlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BasePlugin.kt
@@ -27,9 +27,10 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
  * `io.github.thomaskioko.gradle.plugins.root` on the root project throws a `GradleException` at
  * apply-time so the missing root setup is caught early.
  *
- * The plugin registers the `scaffold {}` extension, applies Spotless, configures the JVM and
- * Kotlin toolchains, sets the project-wide compiler flags (explicit API mode, language version,
- * progressive mode, opt-ins, JVM target), and turns on reproducible JAR output.
+ * The plugin registers the `scaffold {}` extension, applies Spotless, applies the
+ * dependency-analysis plugin per subproject so `buildHealth` aggregates every module, configures
+ * the JVM and Kotlin toolchains, sets the project-wide compiler flags (explicit API mode,
+ * language version, progressive mode, opt-ins, JVM target), and turns on reproducible JAR output.
  *
  * ```kotlin
  * // settings.gradle.kts (root)
@@ -75,6 +76,7 @@ public abstract class BasePlugin : Plugin<Project> {
         requireRootPluginApplied(target)
 
         target.plugins.apply("io.github.thomaskioko.gradle.plugins.spotless")
+        target.plugins.apply("com.autonomousapps.dependency-analysis")
 
         target.scaffoldProperties()
         target.extensions.create("scaffold", BaseExtension::class.java)

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/KotlinMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/KotlinMultiplatformPlugin.kt
@@ -1,9 +1,12 @@
 package io.github.thomaskioko.gradle.plugins
 
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import com.android.build.api.variant.HasDeviceTests
+import com.android.build.api.variant.HasHostTests
 import io.github.thomaskioko.gradle.plugins.setup.configureCommonAndroid
 import io.github.thomaskioko.gradle.plugins.setup.setupTests
 import io.github.thomaskioko.gradle.plugins.utils.addIfNotNull
+import io.github.thomaskioko.gradle.plugins.utils.androidComponents
 import io.github.thomaskioko.gradle.plugins.utils.compilerOptions
 import io.github.thomaskioko.gradle.plugins.utils.disableMultiplatformTasks
 import io.github.thomaskioko.gradle.plugins.utils.getDependencyOrNull
@@ -108,9 +111,23 @@ public abstract class KotlinMultiplatformPlugin : Plugin<Project> {
 
         target.tasks.withType(Test::class.java).configureEach(Test::setupTests)
         target.configureMultiplatformTests()
+        target.configureTestManifestPlaceholders()
         target.disableMultiplatformTasks()
 
         configureMokoResourceBundleCopy(target)
+    }
+
+    private fun Project.configureTestManifestPlaceholders() {
+        androidComponents {
+            onVariants { variant ->
+                (variant as? HasHostTests)?.hostTests?.values?.forEach { hostTest ->
+                    hostTest.manifestPlaceholders.put("appAuthRedirectScheme", "tvmaniac-test")
+                }
+                (variant as? HasDeviceTests)?.deviceTests?.values?.forEach { deviceTest ->
+                    deviceTest.manifestPlaceholders.put("appAuthRedirectScheme", "tvmaniac-test")
+                }
+            }
+        }
     }
 
     private fun Project.configureMultiplatformTests() {

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/RootPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/RootPlugin.kt
@@ -17,11 +17,12 @@ import org.gradle.jvm.toolchain.JvmVendorSpec
  * plugins (`app`, `android`, `jvm`, `multiplatform`, `base`) check for this plugin at apply
  * time and fail with a clear error when it is missing.
  *
- * The plugin applies `com.autonomousapps.dependency-analysis` once at the root, registers the
- * aggregate test tasks ([BasePlugin.LINUX_TEST], [BasePlugin.IOS_TEST], [BasePlugin.ALL_TEST]),
- * sets the JVM vendor on the daemon toolchain task, configures dependency analysis with the
- * project's exclusion list and Compose bundles, and configures Gradle Doctor when the consumer
- * applies it.
+ * The plugin applies `com.autonomousapps.dependency-analysis` at the root for the aggregate
+ * `buildHealth` task and the DSL configuration; `BasePlugin` re-applies the plugin on every
+ * subproject so per-project analysis contributes to the aggregate. Registers the aggregate test
+ * tasks ([BasePlugin.LINUX_TEST], [BasePlugin.IOS_TEST], [BasePlugin.ALL_TEST]), sets the JVM
+ * vendor on the daemon toolchain task, configures dependency analysis with the project's
+ * exclusion list and Compose bundles, and configures Gradle Doctor when the consumer applies it.
  *
  * ```kotlin
  * // root build.gradle.kts


### PR DESCRIPTION
## Description
This PR ensures that the dependency analysis plugin is correctly applied across all subprojects

## Changes
- Apply dependency-analysis plugin per subproject to ensure aggregate build health reporting works correctly.
- Configure `appAuthRedirectScheme` manifest placeholder for Kotlin Multiplatform Android test targets.
- Update plugin documentation to reflect dependency analysis configuration changes.

## Bug Fixes
- Fixed an issue where `AppAuth` dependencies would break Android host and device test manifest processing in KMP modules.
