### PR TITLE
Introduce Feature Flag Codegen and Navigation Lint Rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,8 @@ jobs:
           ./gradlew build \
             :plugins:build \
             :codegen:annotations:build \
+            :codegen:featureflag-annotations:build \
+            :codegen:featureflag-processor:build \
             :codegen:processor:build \
             :codegen:processor-test:build \
             :lint-rules:build \

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -42,6 +42,8 @@ jobs:
           ./gradlew \
             :plugins:publishAndReleaseToMavenCentral \
             :codegen:annotations:publishAndReleaseToMavenCentral \
+            :codegen:featureflag-annotations:publishAndReleaseToMavenCentral \
+            :codegen:featureflag-processor:publishAndReleaseToMavenCentral \
             :codegen:processor:publishAndReleaseToMavenCentral \
             :lint-rules:publishAndReleaseToMavenCentral \
             --no-configuration-cache --stacktrace \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 Change Log
 ==========
 
-an## 0.8.0 *(2026-05-19)*
+## 0.9.0 *(unreleased)*
+
+### Feature flag codegen
+
+New codegen generation module that eliminates the boilerplate every typed feature flag would otherwise require by hand. Decorate a `@Qualifier`-annotated annotation class with `@FeatureFlag(key, title, description, defaultValue, dateAdded)` and the processor emits one `<QualifierBaseName>Binding.kt` next to the qualifier containing the `@Provides @SingleIn @<Qualifier>` factory call plus the `@Provides @IntoSet` rebind into the `Set<FeatureFlag<Boolean>>` multibinding. The hand-written `FlagBindings` interface goes away.
+
+- New module `codegen/featureflag-annotations` (KMP). Public `@FeatureFlag` annotation class. Published as `codegen-featureflag-annotations`.
+- New module `codegen/featureflag-processor` (JVM). `FeatureFlagCodegenProcessor` plus `FeatureFlagBindingGenerator`. Validation covers `InvalidTarget`, `MissingQualifier`, `EmptyKey`, `EmptyTitle`, and `InvalidDate` with each error pinned to the offending symbol. Published as `codegen-featureflag-processor`.
+- New `useFeatureFlagCodegen()` DSL on `BaseExtension`. Mirrors `useCodegen()`: applies KSP (and Metro if absent), registers the processor against `kspCommonMain`, adds the annotation jar to `commonMainImplementation`.
+- Golden tests under `codegen/processor-test/src/test/resources/golden/featureflag/{simple,multi}/`. Update via `-Pgolden.update=true`.
+- Docs at `codegen/docs/featureflag.md`. Consumer contract extended at `codegen/docs/architecture/consumer-contract.md`.
+
+
+## 0.8.0 *(2026-05-19)*
 
 - Refactor dependency analysis exclusions to a DSL-based configuration
 - `tvmaniac:no-manual-nav-binding` flags manual bindings  `@Provides @IntoSet` providers returning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+an## 0.8.0 *(2026-05-19)*
+
+- Refactor dependency analysis exclusions to a DSL-based configuration
+- `tvmaniac:no-manual-nav-binding` flags manual bindings  `@Provides @IntoSet` providers returning
+  `NavRoot`, `NavRootBinding`, `NavDestination`, or `NavRouteBinding`. The codegen processor owns
+  those multibindings whenever a presenter is annotated with `@NavDestination` or `@AppRoot`, so
+  any hand-written contribution duplicates the generated provider.
+
 ## 0.7.9 *(2026-05-17)*
 
 - Fix dependency analysis configuration

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,24 +1,33 @@
-# Navigation Codegen
+# Codegen
 
-KSP based code generation for Kotlin Multiplatform navigation destinations. The codegen targets
-[Decompose](https://arkivanov.github.io/Decompose/) for navigation and
-[Metro](https://zacsweers.github.io/metro/) for dependency injection. It does not work with
-Jetpack Navigation, Voyager, Appyx, or any other navigation library; the generated output references
-Decompose's `ChildStack`, `ChildSlot`, and `ComponentContext` primitives directly.
+KSP based code generation for Kotlin Multiplatform consumers using
+[Metro](https://zacsweers.github.io/metro/) for dependency injection. Two independent tiers:
 
-One annotation (`@NavDestination`) covers stack screens, modal overlays, and bottom navigation tab
-roots. Three more (`@ScreenUi`, `@SheetUi`, `@TabUi`) cover the renderer bindings that join Android
-composables to the navigation host. `@ChildPresenter` covers parent-owned child presenters such as
-tab pager pages. Two more (`@AppRoot`, `@AppRootUi`) cover the application's root presenter and the
-host composable that wraps every other screen. The processor emits the boilerplate that each
-destination would otherwise need: a Metro `@GraphExtension` graph, a `NavDestination` binding for
-the Decompose host (including the `NavRoot` singleton contribution for tabs), a UI renderer binding
-for the Android side, the activity-scope binding container for the root presenter, and the provider
-interface plus extension that lets the activity render the root with one call.
+- **Navigation codegen** targets [Decompose](https://arkivanov.github.io/Decompose/). One annotation
+  (`@NavDestination`) covers stack screens, modal overlays, and bottom navigation tab roots. Three
+  more (`@ScreenUi`, `@SheetUi`, `@TabUi`) cover the renderer bindings that join Android composables
+  to the navigation host. `@ChildPresenter` covers parent-owned child presenters such as tab pager
+  pages. Two more (`@AppRoot`, `@AppRootUi`) cover the application's root presenter and the host
+  composable that wraps every other screen. The processor emits the Metro `@GraphExtension` graph,
+  the `NavDestination` binding for the Decompose host (including the `NavRoot` singleton
+  contribution for tabs), the UI renderer binding for the Android side, the activity-scope binding
+  container for the root presenter, and the provider interface plus extension that lets the
+  activity render the root with one call.
+- **Feature flag codegen** targets typed feature flags backed by a `FeatureFlagFactory`. One
+  annotation (`@FeatureFlag`) decorates a `@Qualifier`-annotated annotation class. The processor
+  emits one `<QualifierBaseName>Binding.kt` per qualifier containing the `@Provides @SingleIn
+  @<Qualifier>` factory call plus the `@Provides @IntoSet` rebind into the
+  `Set<FeatureFlag<Boolean>>` multibinding.
+
+Both tiers do not work with Jetpack Navigation, Voyager, Appyx, Dagger/Hilt, or any other library;
+the generated output references Decompose's `ChildStack`/`ChildSlot`/`ComponentContext` primitives
+and Metro's `@ContributesTo`/`@Provides`/`@IntoSet` directly.
 
 ## What you need
 
-The consumer project must already use Decompose and Metro. Specifically:
+The consumer project must already use Metro. Each tier adds its own requirements:
+
+**Navigation tier:**
 
 - Decompose components hosted as presenters, with each destination identified by a `NavRoute` or
   `NavRoot` class.
@@ -26,21 +35,33 @@ The consumer project must already use Decompose and Metro. Specifically:
 - A Decompose-based navigation host (typically a `ChildStack` for screens plus a `ChildSlot` for
   overlays) that consumes the `Set<NavDestination<*>>` multibinding the codegen contributes to.
 
-The Tv Maniac project is the reference implementation. The full runtime contract, including the
-exact consumer types the generated code references, lives in
+**Feature flag tier:**
+
+- A `FeatureFlag<T>` interface and a `FeatureFlagFactory` with a `boolean(key, title, description,
+  defaultValue, dateAdded)` method.
+- Metro graphs scoped at `AppScope` that the generated `@ContributesTo(AppScope::class)` interface
+  can plug into.
+- `kotlinx-datetime` on every module that declares `@FeatureFlag` qualifiers.
+
+The Tv Maniac project is the reference implementation for both tiers. The full runtime contract,
+including the exact consumer types the generated code references, lives in
 [architecture/consumer-contract.md](docs/architecture/consumer-contract.md).
 
 ## Docs
 
-- [Get started](docs/get-started.md): what the codegen does and how to wire it into a consumer project.
-- [Annotation reference](docs/annotations.md): every parameter and the validation rules the processor enforces.
-- [Examples](docs/examples.md): input and generated output for every variant.
-- [Architecture](docs/architecture/index.md): how the processor is built, for contributors.
+- [Get started (navigation)](docs/get-started.md): what the navigation codegen does and how to wire
+  it into a consumer project.
+- [Feature flag codegen](docs/featureflag.md): the `@FeatureFlag` annotation, generated output, DSL
+  call, and validation rules.
+- [Annotation reference](docs/annotations.md): every navigation annotation parameter and the
+  validation rules the processor enforces.
+- [Examples](docs/examples.md): input and generated output for every navigation variant.
+- [Architecture](docs/architecture/index.md): how the processors are built, for contributors.
 
 ## References
 
-- Decompose: https://arkivanov.github.io/Decompose/
-- Metro: https://zacsweers.github.io/metro/
-- KSP: https://kotlinlang.org/docs/ksp-overview.html
-- kctfork: https://github.com/ZacSweers/kotlin-compile-testing
-- KotlinPoet: https://square.github.io/kotlinpoet/
+- Decompose: <https://arkivanov.github.io/Decompose/>
+- Metro: <https://zacsweers.github.io/metro/>
+- KSP: <https://kotlinlang.org/docs/ksp-overview.html>
+- kctfork: <https://github.com/ZacSweers/kotlin-compile-testing>
+- KotlinPoet: <https://square.github.io/kotlinpoet/>

--- a/codegen/docs/architecture/consumer-contract.md
+++ b/codegen/docs/architecture/consumer-contract.md
@@ -40,6 +40,27 @@ annotation directly on the generated `AppRootContent` extension.
 interface (`RootPresenter` in Tv Maniac), the implementation type, and the host composable all flow through from the annotated symbol via the parser. Consumers can
 rename or repackage these without touching the codegen.
 
+## Feature flag primitives
+
+The feature flag codegen tier in `codegen/featureflag-processor` adds two consumer-side hardcoded names, listed in
+`codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/util/External.kt`.
+
+**Consumer feature flag primitives** under `com.thomaskioko.tvmaniac.featureflags`:
+
+- `FeatureFlag<T>`. The generic interface consumers inject. `FeatureFlagBindingGenerator` parameterises it with `Boolean` in every generated `@Provides` function and
+  `@IntoSet` rebind. Changing the package or renaming the interface breaks every generated binding.
+- `FeatureFlagFactory`. The construction surface. The generator emits `factory.boolean(key, title, description, defaultValue, dateAdded)` calls referencing this type.
+  The factory must declare a `boolean(...)` method with that exact signature; the generator does not branch on alternative shapes.
+
+**Feature flag Metro primitives.** Same `dev.zacsweers.metro` package as the navigation contract, but the feature flag generator also references `AppScope` directly as
+the scope marker for `@ContributesTo(AppScope::class)` and `@SingleIn(AppScope::class)`. Consumers that contribute their feature flags into a different scope must fork
+the processor and edit the matching `External.kt` constant.
+
+**kotlinx.datetime.** `kotlinx.datetime.LocalDate` is the only datetime reference. The generator parses the annotation's `dateAdded` ISO String at codegen time and emits
+a `LocalDate(year, month, day)` constructor call. Consumers must keep `kotlinx-datetime` on the classpath of every module that declares `@FeatureFlag` qualifiers.
+
+The full feature flag codegen reference lives in [featureflag.md](../featureflag.md). The validation rules and error markers are documented there.
+
 ## Runtime flow
 
 The pieces above interact at runtime when the user navigates to a destination. Tracing one navigation request from start to render makes the contract concrete.

--- a/codegen/docs/featureflag.md
+++ b/codegen/docs/featureflag.md
@@ -1,0 +1,175 @@
+# Feature Flag Codegen
+
+A KSP processor that eliminates the Metro binding pair every typed feature flag would otherwise
+require by hand. The processor reads `@FeatureFlag`-decorated qualifier annotations and emits one
+`<QualifierBaseName>Binding.kt` per qualifier into the qualifier's package, removing the
+`FlagBindings` boilerplate consumers used to maintain.
+
+This tier is independent of the navigation codegen documented in
+[get-started.md](get-started.md). Modules that need both call both DSL functions; modules that need
+only one apply only that one.
+
+## Why it exists
+
+Each typed feature flag needs three artifacts that the consumer would otherwise write by hand:
+
+1. A `FooQualifier` annotation, marked with Metro's `@Qualifier`. Stays manual; it is the per-flag
+   handle consumers inject.
+2. A `@Provides @SingleIn(AppScope::class) @FooQualifier` function returning `FeatureFlag<Boolean>`
+   by calling `factory.boolean(key, title, description, defaultValue, dateAdded)`. Mechanical:
+   every flag has the same body shape, only the metadata changes.
+3. A `@Provides @IntoSet` function that takes the qualified `FeatureFlag<Boolean>` and returns it,
+   so the same instance enters the `Set<FeatureFlag<Boolean>>` multibinding the debug screen
+   iterates. Pure delegation; every flag's version is identical except the qualifier annotation.
+
+Items 2 and 3 derive entirely from the qualifier name and the metadata declared on `@FeatureFlag`,
+so the processor emits them from one annotation. The qualifier itself stays manual because it is
+the symbol consumers reference at the injection site.
+
+## What you need
+
+The consumer project must already use Metro and declare a `FeatureFlag<T>` interface plus a
+`FeatureFlagFactory` that builds them. Specifically:
+
+- `com.thomaskioko.tvmaniac.featureflags.FeatureFlag<T>` interface. The generic type the processor
+  parameterises with `Boolean` in every generated binding.
+- `com.thomaskioko.tvmaniac.featureflags.FeatureFlagFactory` with a `boolean(key, title,
+  description, defaultValue, dateAdded)` method returning `FeatureFlag<Boolean>`. The generated
+  `@Provides` function calls this.
+- Metro graphs with `AppScope` that the generated `@ContributesTo(AppScope::class)` interface can
+  plug into.
+- `kotlinx.datetime.LocalDate` on the consumer's classpath; the generated `dateAdded =
+  LocalDate(year, month, day)` literal resolves against it.
+
+Type names are hardcoded in
+[architecture/consumer-contract.md](architecture/consumer-contract.md#feature-flag-primitives).
+
+The [Tv Maniac](https://github.com/c0de-wizard/tv-maniac) project is the reference consumer.
+
+## Wire it up
+
+Add the codegen dependency aliases to the consumer's `gradle/libs.versions.toml`:
+
+```toml
+codegen-featureflag-annotations = { module = "io.github.thomaskioko.gradle.plugins:codegen-featureflag-annotations", version.ref = "app-gradle-plugins" }
+codegen-featureflag-processor = { module = "io.github.thomaskioko.gradle.plugins:codegen-featureflag-processor", version.ref = "app-gradle-plugins" }
+```
+
+Then enable the DSL in each module that declares feature flag qualifiers:
+
+```kotlin
+scaffold {
+    useMetro()
+    useFeatureFlagCodegen()
+}
+```
+
+`useFeatureFlagCodegen()` applies KSP (and Metro, if absent), adds the annotation jar to
+`commonMainImplementation`, and registers the processor against `kspCommonMain`. The DSL is
+independent of `useCodegen()`; modules that consume both navigation and feature flag codegen call
+both functions.
+
+## Annotation reference
+
+`@FeatureFlag` decorates a `@Qualifier`-annotated annotation class. Parameters:
+
+| Parameter      | Type      | Description                                                           |
+|----------------|-----------|-----------------------------------------------------------------------|
+| `key`          | `String`  | Firebase Remote Config key. Drives lookups and debug-store overrides. |
+| `title`        | `String`  | Human-readable name shown on the debug screen row.                    |
+| `description`  | `String`  | One-line summary shown beneath the title.                             |
+| `defaultValue` | `Boolean` | Fallback returned until Firebase serves an explicit value.            |
+| `dateAdded`    | `String`  | ISO `YYYY-MM-DD` date the flag entered the codebase.                  |
+
+`dateAdded` is a `String` because Kotlin annotations cannot accept `LocalDate`. The processor
+parses to `kotlinx.datetime.LocalDate` at codegen time and emits a `LocalDate(year, month, day)`
+constructor call in the generated code.
+
+## Example
+
+Input (hand-written):
+
+```kotlin
+package com.thomaskioko.tvmaniac.featureflags.flags
+
+import dev.zacsweers.metro.Qualifier
+import io.github.thomaskioko.codegen.annotations.FeatureFlag
+
+@Qualifier
+@FeatureFlag(
+    key = "enable_continue_watching_nitro",
+    title = "Progress Endpoint",
+    description = "Use Trakt's internal /sync/progress/up_next_nitro call instead of the documented multi-step progress fetch.",
+    defaultValue = false,
+    dateAdded = "2026-05-20",
+)
+public annotation class ContinueWatchingNitroFlagQualifier
+```
+
+Output (generated into the same package, file `ContinueWatchingNitroFlagBinding.kt`):
+
+```kotlin
+package com.thomaskioko.tvmaniac.featureflags.flags
+
+import com.thomaskioko.tvmaniac.featureflags.FeatureFlag
+import com.thomaskioko.tvmaniac.featureflags.FeatureFlagFactory
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import kotlin.Boolean
+import kotlinx.datetime.LocalDate
+
+@ContributesTo(AppScope::class)
+public interface ContinueWatchingNitroFlagBinding {
+  @Provides
+  @SingleIn(AppScope::class)
+  @ContinueWatchingNitroFlagQualifier
+  public fun provideContinueWatchingNitroFlag(factory: FeatureFlagFactory): FeatureFlag<Boolean> = factory.boolean(
+      key = "enable_continue_watching_nitro",
+      title = "Progress Endpoint",
+      description = "Use Trakt's internal /sync/progress/up_next_nitro call instead of the documented multi-step progress fetch.",
+      defaultValue = false,
+      dateAdded = LocalDate(2_026, 5, 20),
+  )
+
+  @Provides
+  @IntoSet
+  public fun bindContinueWatchingNitroFlag(@ContinueWatchingNitroFlagQualifier flag: FeatureFlag<Boolean>): FeatureFlag<Boolean> = flag
+}
+```
+
+The base name (`ContinueWatchingNitroFlag`) comes from the qualifier's simple name with a trailing
+`Qualifier` suffix stripped. Qualifiers without the suffix keep their name as the base name.
+
+## Validation
+
+The processor reports a compile error pinned to the offending symbol whenever any of these hold:
+
+| Marker                           | Rule                                                                              |
+|----------------------------------|-----------------------------------------------------------------------------------|
+| `[FeatureFlag/InvalidTarget]`    | The annotated symbol is not an `annotation class`.                                |
+| `[FeatureFlag/MissingQualifier]` | The annotation class is not also annotated with `@dev.zacsweers.metro.Qualifier`. |
+| `[FeatureFlag/EmptyKey]`         | `key` is blank.                                                                   |
+| `[FeatureFlag/EmptyTitle]`       | `title` is blank.                                                                 |
+| `[FeatureFlag/InvalidDate]`      | `dateAdded` does not parse as a valid ISO `YYYY-MM-DD` date.                      |
+
+Each error message names the qualifier so the IDE error log identifies the failing flag.
+
+## Out of scope
+
+- Non-Boolean flag types (`enum`, `integer`, `string`). The processor emits `factory.boolean(...)`
+  only. Additional methods land when the consumer adds the first non-Boolean flag.
+- Spec-file-driven codegen. The annotation-on-qualifier approach is intentional; spec-file mode is
+  a separate future option.
+- Consolidated `GeneratedFlagBindings.kt` per consumer. Per-qualifier files are independent and
+  need no cross-round bookkeeping.
+
+## References
+
+- [Consumer contract](architecture/consumer-contract.md#feature-flag-primitives): the full list of
+  hardcoded type names the generated code references.
+- [Navigation codegen](get-started.md): the sibling codegen tier for Decompose-based navigation.
+- KSP: <https://kotlinlang.org/docs/ksp-overview.html>
+- KotlinPoet: <https://square.github.io/kotlinpoet/>

--- a/codegen/featureflag-annotations/build.gradle.kts
+++ b/codegen/featureflag-annotations/build.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.publish)
+}
+
+group = property("GROUP").toString()
+version = property("VERSION_NAME").toString()
+
+kotlin {
+    jvm()
+    iosArm64()
+    iosSimulatorArm64()
+
+    explicitApi()
+}
+
+mavenPublishing {
+    coordinates(artifactId = "codegen-featureflag-annotations")
+    publishToMavenCentral(automaticRelease = true)
+    if (findProperty("maven.central.publish")?.toString() == "true") {
+        signAllPublications()
+    }
+
+    pom {
+        name.set(property("POM_NAME").toString())
+        description.set("Feature flag codegen annotations consumed by KMP modules")
+        inceptionYear.set(property("INCEPTION_YEAR").toString())
+        url.set(property("POM_URL").toString())
+
+        licenses {
+            license {
+                name.set(property("POM_LICENSE_NAME").toString())
+                url.set(property("POM_LICENSE_URL").toString())
+                distribution.set(property("POM_LICENSE_DIST").toString())
+            }
+        }
+
+        developers {
+            developer {
+                id.set(property("POM_DEVELOPER_ID").toString())
+                name.set(property("POM_DEVELOPER_NAME").toString())
+                url.set(property("POM_DEVELOPER_URL").toString())
+            }
+        }
+
+        scm {
+            url.set(property("POM_SCM_URL").toString())
+            connection.set(property("POM_SCM_CONNECTION").toString())
+            developerConnection.set(property("POM_SCM_DEV_CONNECTION").toString())
+        }
+    }
+}

--- a/codegen/featureflag-annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/FeatureFlag.kt
+++ b/codegen/featureflag-annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/FeatureFlag.kt
@@ -1,0 +1,61 @@
+package io.github.thomaskioko.codegen.annotations
+
+/**
+ * Decorates a `@Qualifier`-annotated annotation class to declare a feature flag, so the codegen
+ * processor can emit the Metro binding pair that wires the flag through `FeatureFlagFactory`.
+ *
+ * Without this annotation the consumer hand-writes two `@Provides` functions per flag inside a
+ * `FlagBindings` interface: one returning the qualified `FeatureFlag<Boolean>` via
+ * `factory.boolean(...)`, and one binding that same instance into the
+ * `Set<FeatureFlag<Boolean>>` multibinding the debug screen iterates. With this annotation the
+ * processor emits both functions next to the qualifier declaration.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * @Qualifier
+ * @FeatureFlag(
+ *     key = "enable_continue_watching_nitro",
+ *     title = "Progress Endpoint",
+ *     description = "Use Trakt's internal /sync/progress/up_next_nitro call instead of the documented multi-step progress fetch.",
+ *     defaultValue = false,
+ *     dateAdded = "2026-05-20",
+ * )
+ * annotation class ContinueWatchingNitroFlagQualifier
+ * ```
+ *
+ * The processor emits one file (`<QualifierBaseName>Binding.kt`) into the qualifier's package. The
+ * file contains a `@ContributesTo(AppScope::class)` interface declaring two `@Provides` methods:
+ * one qualified factory call and one `@IntoSet` rebind into `Set<FeatureFlag<Boolean>>`.
+ *
+ * The `<QualifierBaseName>` is the qualifier's `simpleName` with a trailing `Qualifier` suffix
+ * stripped if present. `ContinueWatchingNitroFlagQualifier` becomes `ContinueWatchingNitroFlag`;
+ * `MyFlag` (no suffix) stays as `MyFlag`. The emitted interface is named `<QualifierBaseName>Binding`.
+ *
+ * ## Validation
+ *
+ * The processor reports a compile error if any of the following hold:
+ *
+ * - The annotated symbol is not an `annotation class`.
+ * - The annotated class does not also carry `@dev.zacsweers.metro.Qualifier`.
+ * - [key] is blank.
+ * - [title] is blank.
+ * - [dateAdded] is not a valid ISO `YYYY-MM-DD` date.
+ *
+ * @property key Firebase Remote Config key. Drives both Firebase lookups and debug-store overrides.
+ * @property title Human-readable name shown on the debug screen row.
+ * @property description One-line summary shown beneath the title on the debug screen.
+ * @property defaultValue Fallback returned until Firebase serves an explicit value.
+ * @property dateAdded ISO `YYYY-MM-DD` date the flag entered the codebase. Drives the debug
+ *   screen's "Date Added" sort. Stored as `String` because Kotlin annotations cannot accept
+ *   `LocalDate`; the processor parses to `kotlinx.datetime.LocalDate` at codegen time.
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class FeatureFlag(
+    val key: String,
+    val title: String,
+    val description: String,
+    val defaultValue: Boolean,
+    val dateAdded: String,
+)

--- a/codegen/featureflag-processor/build.gradle.kts
+++ b/codegen/featureflag-processor/build.gradle.kts
@@ -1,0 +1,65 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.publish)
+}
+
+group = property("GROUP").toString()
+version = property("VERSION_NAME").toString()
+
+kotlin {
+    explicitApi()
+    jvmToolchain(libs.versions.java.toolchain.get().toInt())
+    compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.target.get()))
+    }
+}
+
+java {
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.target.get())
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.target.get())
+}
+
+dependencies {
+    api(libs.ksp.api)
+    implementation(libs.kotlinpoet)
+    implementation(libs.kotlinpoet.ksp)
+}
+
+mavenPublishing {
+    coordinates(artifactId = "codegen-featureflag-processor")
+    publishToMavenCentral(automaticRelease = true)
+    if (findProperty("maven.central.publish")?.toString() == "true") {
+        signAllPublications()
+    }
+
+    pom {
+        name.set(property("POM_NAME").toString())
+        description.set("KSP processor for generating feature flag Metro bindings")
+        inceptionYear.set(property("INCEPTION_YEAR").toString())
+        url.set(property("POM_URL").toString())
+
+        licenses {
+            license {
+                name.set(property("POM_LICENSE_NAME").toString())
+                url.set(property("POM_LICENSE_URL").toString())
+                distribution.set(property("POM_LICENSE_DIST").toString())
+            }
+        }
+
+        developers {
+            developer {
+                id.set(property("POM_DEVELOPER_ID").toString())
+                name.set(property("POM_DEVELOPER_NAME").toString())
+                url.set(property("POM_DEVELOPER_URL").toString())
+            }
+        }
+
+        scm {
+            url.set(property("POM_SCM_URL").toString())
+            connection.set(property("POM_SCM_CONNECTION").toString())
+            developerConnection.set(property("POM_SCM_DEV_CONNECTION").toString())
+        }
+    }
+}

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagBindingGenerator.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagBindingGenerator.kt
@@ -1,0 +1,106 @@
+package io.github.thomaskioko.codegen.featureflag.processor
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeSpec
+import io.github.thomaskioko.codegen.featureflag.processor.util.AppScope
+import io.github.thomaskioko.codegen.featureflag.processor.util.ContributesTo
+import io.github.thomaskioko.codegen.featureflag.processor.util.FeatureFlag
+import io.github.thomaskioko.codegen.featureflag.processor.util.FeatureFlagFactory
+import io.github.thomaskioko.codegen.featureflag.processor.util.IntoSet
+import io.github.thomaskioko.codegen.featureflag.processor.util.LocalDate
+import io.github.thomaskioko.codegen.featureflag.processor.util.Provides
+import io.github.thomaskioko.codegen.featureflag.processor.util.SingleIn
+
+/**
+ * Emits the per-qualifier binding file for one `@FeatureFlag`-decorated qualifier annotation.
+ *
+ * The output is one [FileSpec] containing a `@ContributesTo(AppScope::class) public interface
+ * <baseName>Binding` with two `@Provides` methods:
+ *
+ * - `provide<baseName>(factory: FeatureFlagFactory): FeatureFlag<Boolean>` — qualified with the
+ *   consumer's qualifier annotation and `@SingleIn(AppScope::class)`. Body calls
+ *   `factory.boolean(key, title, description, defaultValue, dateAdded)` with the literal arguments
+ *   parsed from the source annotation.
+ * - `bind<baseName>(flag: FeatureFlag<Boolean>): FeatureFlag<Boolean>` — annotated `@IntoSet`. Body
+ *   returns the qualified parameter so the same instance enters the
+ *   `Set<FeatureFlag<Boolean>>` multibinding.
+ *
+ * The generated interface is `public` so the consumer's IDE can navigate to it and so Metro can
+ * pick up the contributed methods.
+ */
+internal object FeatureFlagBindingGenerator {
+
+    /**
+     * Builds the binding file for one parsed [FeatureFlagData].
+     *
+     * @param data The parsed annotation arguments and computed names.
+     * @return A KotlinPoet [FileSpec] ready to write to `<packageName>.<baseName>Binding.kt`.
+     */
+    fun generate(data: FeatureFlagData): FileSpec {
+        val flagOfBoolean = FeatureFlag.parameterizedBy(BOOLEAN)
+
+        val provideFun = FunSpec.builder("provide${data.baseName}")
+            .addModifiers(KModifier.PUBLIC)
+            .addAnnotation(AnnotationSpec.builder(Provides).build())
+            .addAnnotation(
+                AnnotationSpec.builder(SingleIn)
+                    .addMember("%T::class", AppScope)
+                    .build(),
+            )
+            .addAnnotation(AnnotationSpec.builder(data.qualifierClassName).build())
+            .addParameter("factory", FeatureFlagFactory)
+            .returns(flagOfBoolean)
+            .addStatement(
+                "return factory.boolean(\n" +
+                    "    key = %S,\n" +
+                    "    title = %S,\n" +
+                    "    description = %S,\n" +
+                    "    defaultValue = %L,\n" +
+                    "    dateAdded = %T(%L, %L, %L),\n" +
+                    ")",
+                data.key,
+                data.title,
+                data.description,
+                data.defaultValue,
+                LocalDate,
+                data.year,
+                data.month,
+                data.day,
+            )
+            .build()
+
+        val bindFun = FunSpec.builder("bind${data.baseName}")
+            .addModifiers(KModifier.PUBLIC)
+            .addAnnotation(AnnotationSpec.builder(Provides).build())
+            .addAnnotation(AnnotationSpec.builder(IntoSet).build())
+            .addParameter(
+                ParameterSpec.builder("flag", flagOfBoolean)
+                    .addAnnotation(AnnotationSpec.builder(data.qualifierClassName).build())
+                    .build(),
+            )
+            .returns(flagOfBoolean)
+            .addStatement("return flag")
+            .build()
+
+        val bindingInterface = TypeSpec.interfaceBuilder("${data.baseName}Binding")
+            .addModifiers(KModifier.PUBLIC)
+            .addAnnotation(
+                AnnotationSpec.builder(ContributesTo)
+                    .addMember("%T::class", AppScope)
+                    .build(),
+            )
+            .addFunction(provideFun)
+            .addFunction(bindFun)
+            .build()
+
+        return FileSpec.builder(data.packageName, "${data.baseName}Binding")
+            .addType(bindingInterface)
+            .build()
+    }
+}

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagCodegenProcessor.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagCodegenProcessor.kt
@@ -1,0 +1,194 @@
+package io.github.thomaskioko.codegen.featureflag.processor
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.writeTo
+
+/**
+ * KSP processor that turns `@FeatureFlag`-decorated qualifier annotations into Metro binding
+ * interfaces. Loaded once per build by KSP through [FeatureFlagCodegenProcessorProvider].
+ *
+ * For each annotated symbol the processor validates the shape (annotation class, has `@Qualifier`,
+ * non-blank `key` and `title`, ISO-formatted `dateAdded`), parses the annotation arguments,
+ * computes the base name (qualifier simple name minus trailing `Qualifier` suffix), and hands the
+ * result to [FeatureFlagBindingGenerator] which emits one `<BaseName>Binding.kt` file into the
+ * qualifier's package. The processor never throws on bad input. Validation failures are reported
+ * through [KSPLogger.error] pinned to the offending symbol so KSP turns them into compile errors at
+ * the source position.
+ *
+ * @property codeGenerator KSP's file writer. Receives every produced [FileSpec].
+ * @property logger KSP's diagnostic sink. Reports validation errors pinned to symbols.
+ */
+public class FeatureFlagCodegenProcessor(
+    private val codeGenerator: CodeGenerator,
+    private val logger: KSPLogger,
+) : SymbolProcessor {
+
+    /**
+     * Runs one KSP round. Iterates every symbol annotated with `@FeatureFlag`, validates and
+     * parses each into a [FeatureFlagData], and writes one binding file per symbol.
+     *
+     * @param resolver KSP's lookup interface for the current round.
+     * @return An empty list. The processor does not defer work to later rounds.
+     */
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        for (symbol in resolver.getSymbolsWithAnnotation(FEATURE_FLAG_FQN)) {
+            val declaration = symbol as? KSClassDeclaration ?: run {
+                logger.error(
+                    "[FeatureFlag/InvalidTarget] @FeatureFlag must annotate an annotation class. " +
+                        "Saw it on a non-class symbol.",
+                    symbol,
+                )
+                continue
+            }
+            val data = parse(declaration) ?: continue
+            writeFile(declaration, FeatureFlagBindingGenerator.generate(data))
+        }
+        return emptyList()
+    }
+
+    /**
+     * Validates and parses the `@FeatureFlag` annotation on [declaration].
+     *
+     * Returns `null` and logs a compile error via [KSPLogger.error] when any validation rule fails:
+     * the target is not an annotation class, the annotation class lacks `@Qualifier`, `key` is
+     * blank, `title` is blank, or `dateAdded` does not parse as an ISO `YYYY-MM-DD` date.
+     */
+    private fun parse(declaration: KSClassDeclaration): FeatureFlagData? {
+        val qualifierName = declaration.simpleName.asString()
+
+        if (declaration.classKind != ClassKind.ANNOTATION_CLASS) {
+            logger.error(
+                "[FeatureFlag/InvalidTarget] @FeatureFlag must annotate an annotation class. " +
+                    "Saw @$qualifierName on a ${declaration.classKind.type}.",
+                declaration,
+            )
+            return null
+        }
+
+        if (!declaration.hasAnnotation(QUALIFIER_FQN)) {
+            logger.error(
+                "[FeatureFlag/MissingQualifier] @FeatureFlag must be applied to an annotation " +
+                    "class also annotated with @dev.zacsweers.metro.Qualifier. " +
+                    "Saw @$qualifierName declared without @Qualifier.",
+                declaration,
+            )
+            return null
+        }
+
+        val annotation = declaration.annotations.firstOrNull { it.shortName.asString() == FEATURE_FLAG_SHORT_NAME }
+            ?: run {
+                logger.error("Missing @FeatureFlag annotation", declaration)
+                return null
+            }
+
+        val key = annotation.stringArgument("key")
+        if (key.isBlank()) {
+            logger.error(
+                "[FeatureFlag/EmptyKey] @FeatureFlag(key = \"\") on @$qualifierName is invalid. " +
+                    "Provide the Firebase Remote Config key.",
+                declaration,
+            )
+            return null
+        }
+
+        val title = annotation.stringArgument("title")
+        if (title.isBlank()) {
+            logger.error(
+                "[FeatureFlag/EmptyTitle] @FeatureFlag(title = \"\") on @$qualifierName is invalid. " +
+                    "Provide the debug-screen title.",
+                declaration,
+            )
+            return null
+        }
+
+        val description = annotation.stringArgument("description")
+        val defaultValue = annotation.booleanArgument("defaultValue")
+        val dateAdded = annotation.stringArgument("dateAdded")
+        val date = parseIsoDate(dateAdded)
+        if (date == null) {
+            logger.error(
+                "[FeatureFlag/InvalidDate] @FeatureFlag(dateAdded = \"$dateAdded\") on " +
+                    "@$qualifierName is not a valid ISO date (YYYY-MM-DD).",
+                declaration,
+            )
+            return null
+        }
+
+        val baseName = qualifierName.removeSuffix(QUALIFIER_SUFFIX)
+
+        return FeatureFlagData(
+            packageName = declaration.packageName.asString(),
+            qualifierClassName = declaration.toClassName(),
+            baseName = baseName,
+            key = key,
+            title = title,
+            description = description,
+            defaultValue = defaultValue,
+            year = date.year,
+            month = date.month,
+            day = date.day,
+        )
+    }
+
+    /**
+     * Writes [file] to disk via KSP's [CodeGenerator]. Uses `aggregating = false` so the output
+     * depends only on the source file the annotation lives in; editing one flag does not
+     * invalidate sibling flags.
+     */
+    private fun writeFile(source: KSClassDeclaration, file: FileSpec) {
+        val containingFile = source.containingFile ?: run {
+            logger.warn("Cannot determine containing file for ${source.qualifiedName?.asString()}", source)
+            return
+        }
+        file.writeTo(codeGenerator, Dependencies(aggregating = false, containingFile))
+    }
+
+    private fun KSClassDeclaration.hasAnnotation(fqn: String): Boolean =
+        annotations.any { it.annotationType.resolve().declaration.qualifiedName?.asString() == fqn }
+
+    private fun KSAnnotation.stringArgument(name: String): String {
+        val value = arguments.firstOrNull { it.name?.asString() == name }?.value
+            ?: defaultArguments.firstOrNull { it.name?.asString() == name }?.value
+            ?: error("@FeatureFlag missing required '$name' argument")
+        return value as? String
+            ?: error("@FeatureFlag '$name' argument is not a String (got ${value::class.simpleName})")
+    }
+
+    private fun KSAnnotation.booleanArgument(name: String): Boolean {
+        val value = arguments.firstOrNull { it.name?.asString() == name }?.value
+            ?: defaultArguments.firstOrNull { it.name?.asString() == name }?.value
+            ?: error("@FeatureFlag missing required '$name' argument")
+        return value as? Boolean
+            ?: error("@FeatureFlag '$name' argument is not a Boolean (got ${value::class.simpleName})")
+    }
+
+    private fun parseIsoDate(value: String): IsoDate? {
+        val parts = value.split('-')
+        if (parts.size != 3) return null
+        val year = parts[0].toIntOrNull() ?: return null
+        val month = parts[1].toIntOrNull() ?: return null
+        val day = parts[2].toIntOrNull() ?: return null
+        if (month !in 1..12) return null
+        if (day !in 1..31) return null
+        return IsoDate(year, month, day)
+    }
+
+    private data class IsoDate(val year: Int, val month: Int, val day: Int)
+
+    internal companion object {
+        internal const val FEATURE_FLAG_FQN: String = "io.github.thomaskioko.codegen.annotations.FeatureFlag"
+        internal const val FEATURE_FLAG_SHORT_NAME: String = "FeatureFlag"
+        internal const val QUALIFIER_FQN: String = "dev.zacsweers.metro.Qualifier"
+        internal const val QUALIFIER_SUFFIX: String = "Qualifier"
+    }
+}

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagCodegenProcessorProvider.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagCodegenProcessorProvider.kt
@@ -1,0 +1,29 @@
+package io.github.thomaskioko.codegen.featureflag.processor
+
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+
+/**
+ * KSP entry point for the feature flag codegen processor. KSP loads this through
+ * `META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider` and calls
+ * [create] once per build to obtain the [FeatureFlagCodegenProcessor] that will run for that
+ * build.
+ *
+ * Consumer wiring lives in the `useFeatureFlagCodegen()` extension on the `scaffold {}` Gradle
+ * DSL. Consumers do not reference this class directly.
+ */
+public class FeatureFlagCodegenProcessorProvider : SymbolProcessorProvider {
+    /**
+     * Creates the [FeatureFlagCodegenProcessor] KSP will run for the current build.
+     *
+     * @param environment KSP's per build environment. Provides the file writer and diagnostic
+     *   logger the processor needs.
+     * @return A new processor instance bound to the supplied environment.
+     */
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
+        FeatureFlagCodegenProcessor(
+            codeGenerator = environment.codeGenerator,
+            logger = environment.logger,
+        )
+}

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagData.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagData.kt
@@ -1,0 +1,37 @@
+package io.github.thomaskioko.codegen.featureflag.processor
+
+import com.squareup.kotlinpoet.ClassName
+
+/**
+ * Typed intermediate representation of one `@FeatureFlag`-decorated qualifier annotation.
+ *
+ * Produced by [FeatureFlagCodegenProcessor] after parsing the annotation arguments and computing
+ * the base name. Consumed by [FeatureFlagBindingGenerator] to emit the per-qualifier binding file.
+ *
+ * @property packageName Package of the annotated qualifier class. The generated binding file
+ *   lives in the same package so it sits next to the qualifier declaration.
+ * @property qualifierClassName Fully qualified name of the annotated qualifier class. Referenced
+ *   by the generated `@Provides` function and the `@IntoSet` rebind parameter.
+ * @property baseName The qualifier's simple name with a trailing `Qualifier` suffix removed (if
+ *   present). Drives the generated interface name (`<baseName>Binding`) and the generated function
+ *   names (`provide<baseName>`, `bind<baseName>`).
+ * @property key Firebase Remote Config key. Passed verbatim to `factory.boolean(...)`.
+ * @property title Human-readable name. Passed verbatim to `factory.boolean(...)`.
+ * @property description One-line summary. Passed verbatim to `factory.boolean(...)`.
+ * @property defaultValue Fallback Boolean. Passed verbatim to `factory.boolean(...)`.
+ * @property year Year component of `dateAdded`. Emitted as a literal in the `LocalDate(...)` call.
+ * @property month Month component of `dateAdded` (1..12). Emitted as a literal.
+ * @property day Day-of-month component of `dateAdded` (1..31). Emitted as a literal.
+ */
+internal data class FeatureFlagData(
+    val packageName: String,
+    val qualifierClassName: ClassName,
+    val baseName: String,
+    val key: String,
+    val title: String,
+    val description: String,
+    val defaultValue: Boolean,
+    val year: Int,
+    val month: Int,
+    val day: Int,
+)

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/util/External.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/util/External.kt
@@ -1,0 +1,40 @@
+package io.github.thomaskioko.codegen.featureflag.processor.util
+
+import com.squareup.kotlinpoet.ClassName
+
+/*
+ * Fully qualified `ClassName` constants for every type the generated code references in the
+ * consumer project. Used by [FeatureFlagBindingGenerator] so the names live in one place.
+ *
+ * These are constants rather than configurable processor options. The rationale matches the
+ * navigation processor's `External.kt`: a fork that changes the consumer's feature flag primitives
+ * edits this file and the matching test stubs in `processor-test/`. The constants are deliberately
+ * `internal` and impossible to override without a fork, which keeps the upstream processor
+ * opinionated and small.
+ *
+ * The groupings below match the role each name plays at runtime.
+ */
+
+// Consumer feature flag primitives. The generated binding references the generic interface
+// (FeatureFlag<Boolean>) and the construction surface (FeatureFlagFactory). The interface is the
+// type consumers inject; the factory builds the underlying RemoteFlag through the consumer's
+// FeatureFlagsRemoteConfig wiring.
+internal const val FEATURE_FLAGS_PACKAGE: String = "com.thomaskioko.tvmaniac.featureflags"
+internal val FeatureFlag: ClassName = ClassName(FEATURE_FLAGS_PACKAGE, "FeatureFlag")
+internal val FeatureFlagFactory: ClassName = ClassName(FEATURE_FLAGS_PACKAGE, "FeatureFlagFactory")
+
+// Metro: the dependency injection framework the codegen targets. Every generated annotation
+// references one of these. AppScope is the parent dependency injection scope the generated
+// interface contributes into.
+internal const val METRO_PACKAGE: String = "dev.zacsweers.metro"
+internal val AppScope: ClassName = ClassName(METRO_PACKAGE, "AppScope")
+internal val ContributesTo: ClassName = ClassName(METRO_PACKAGE, "ContributesTo")
+internal val IntoSet: ClassName = ClassName(METRO_PACKAGE, "IntoSet")
+internal val Provides: ClassName = ClassName(METRO_PACKAGE, "Provides")
+internal val SingleIn: ClassName = ClassName(METRO_PACKAGE, "SingleIn")
+
+// kotlinx.datetime: the LocalDate type the generated factory call passes for the `dateAdded`
+// parameter. The processor parses the annotation's ISO String at codegen time and emits a
+// LocalDate constructor call with year, month, day literals.
+internal const val DATETIME_PACKAGE: String = "kotlinx.datetime"
+internal val LocalDate: ClassName = ClassName(DATETIME_PACKAGE, "LocalDate")

--- a/codegen/featureflag-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/codegen/featureflag-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+io.github.thomaskioko.codegen.featureflag.processor.FeatureFlagCodegenProcessorProvider

--- a/codegen/processor-test/build.gradle.kts
+++ b/codegen/processor-test/build.gradle.kts
@@ -18,7 +18,9 @@ java {
 
 dependencies {
     testImplementation(project(":processor"))
+    testImplementation(project(":featureflag-processor"))
     testRuntimeOnly(project(":annotations"))
+    testRuntimeOnly(project(":featureflag-annotations"))
     testImplementation(libs.kctfork.ksp)
     testImplementation(libs.kctfork.core)
     testImplementation(libs.junit)

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagErrorPathTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagErrorPathTest.kt
@@ -1,0 +1,147 @@
+package io.github.thomaskioko.codegen.featureflag
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCompilerApi::class)
+class FeatureFlagErrorPathTest {
+
+    @Test
+    fun `should report InvalidTarget when FeatureFlag is on a non-annotation class`() {
+        val sources = FeatureFlagStubs.baseStubs.toMap() + mapOf(
+            "NotAnAnnotation.kt" to """
+                package com.thomaskioko.tvmaniac.featureflags.flags
+
+                import io.github.thomaskioko.codegen.annotations.FeatureFlag
+
+                @FeatureFlag(
+                    key = "some_key",
+                    title = "Some Title",
+                    description = "Some description.",
+                    defaultValue = false,
+                    dateAdded = "2026-05-20",
+                )
+                public class NotAnAnnotation
+            """.trimIndent(),
+        )
+
+        val result = FeatureFlagTestRunner().run(sources)
+        assertCompilationError(result, "[FeatureFlag/InvalidTarget]")
+    }
+
+    @Test
+    fun `should report MissingQualifier when annotation class lacks @Qualifier`() {
+        val sources = FeatureFlagStubs.baseStubs.toMap() + mapOf(
+            "MissingQualifier.kt" to """
+                package com.thomaskioko.tvmaniac.featureflags.flags
+
+                import io.github.thomaskioko.codegen.annotations.FeatureFlag
+
+                @FeatureFlag(
+                    key = "some_key",
+                    title = "Some Title",
+                    description = "Some description.",
+                    defaultValue = false,
+                    dateAdded = "2026-05-20",
+                )
+                public annotation class MissingQualifierFlagQualifier
+            """.trimIndent(),
+        )
+
+        val result = FeatureFlagTestRunner().run(sources)
+        assertCompilationError(result, "[FeatureFlag/MissingQualifier]")
+    }
+
+    @Test
+    fun `should report EmptyKey when key is blank`() {
+        val sources = FeatureFlagStubs.baseStubs.toMap() + mapOf(
+            "EmptyKey.kt" to """
+                package com.thomaskioko.tvmaniac.featureflags.flags
+
+                import dev.zacsweers.metro.Qualifier
+                import io.github.thomaskioko.codegen.annotations.FeatureFlag
+
+                @Qualifier
+                @FeatureFlag(
+                    key = "",
+                    title = "Some Title",
+                    description = "Some description.",
+                    defaultValue = false,
+                    dateAdded = "2026-05-20",
+                )
+                public annotation class EmptyKeyFlagQualifier
+            """.trimIndent(),
+        )
+
+        val result = FeatureFlagTestRunner().run(sources)
+        assertCompilationError(result, "[FeatureFlag/EmptyKey]")
+    }
+
+    @Test
+    fun `should report EmptyTitle when title is blank`() {
+        val sources = FeatureFlagStubs.baseStubs.toMap() + mapOf(
+            "EmptyTitle.kt" to """
+                package com.thomaskioko.tvmaniac.featureflags.flags
+
+                import dev.zacsweers.metro.Qualifier
+                import io.github.thomaskioko.codegen.annotations.FeatureFlag
+
+                @Qualifier
+                @FeatureFlag(
+                    key = "some_key",
+                    title = "",
+                    description = "Some description.",
+                    defaultValue = false,
+                    dateAdded = "2026-05-20",
+                )
+                public annotation class EmptyTitleFlagQualifier
+            """.trimIndent(),
+        )
+
+        val result = FeatureFlagTestRunner().run(sources)
+        assertCompilationError(result, "[FeatureFlag/EmptyTitle]")
+    }
+
+    @Test
+    fun `should report InvalidDate when dateAdded is malformed`() {
+        val sources = FeatureFlagStubs.baseStubs.toMap() + mapOf(
+            "InvalidDate.kt" to """
+                package com.thomaskioko.tvmaniac.featureflags.flags
+
+                import dev.zacsweers.metro.Qualifier
+                import io.github.thomaskioko.codegen.annotations.FeatureFlag
+
+                @Qualifier
+                @FeatureFlag(
+                    key = "some_key",
+                    title = "Some Title",
+                    description = "Some description.",
+                    defaultValue = false,
+                    dateAdded = "not-a-date",
+                )
+                public annotation class InvalidDateFlagQualifier
+            """.trimIndent(),
+        )
+
+        val result = FeatureFlagTestRunner().run(sources)
+        assertCompilationError(result, "[FeatureFlag/InvalidDate]")
+    }
+
+    private fun assertCompilationError(
+        result: FeatureFlagTestRunner.RunResult,
+        expectedMarker: String,
+    ) {
+        assertEquals(
+            "Expected compilation failure but it succeeded.\nMessages:\n${result.messages}",
+            KotlinCompilation.ExitCode.COMPILATION_ERROR,
+            result.exitCode,
+        )
+        assertTrue(
+            "Expected diagnostic containing '$expectedMarker' but messages were:\n${result.messages}",
+            result.messages.contains(expectedMarker),
+        )
+    }
+}

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagMultiFlagTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagMultiFlagTest.kt
@@ -1,0 +1,68 @@
+package io.github.thomaskioko.codegen.featureflag
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.github.thomaskioko.codegen.processor.GoldenFileAssert
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCompilerApi::class)
+class FeatureFlagMultiFlagTest {
+
+    @Test
+    fun `should generate one binding file per FeatureFlag-decorated qualifier`() {
+        val sources = FeatureFlagStubs.baseStubs.toMap() + mapOf(
+            "Qualifiers.kt" to """
+                package com.thomaskioko.tvmaniac.featureflags.flags
+
+                import dev.zacsweers.metro.Qualifier
+                import io.github.thomaskioko.codegen.annotations.FeatureFlag
+
+                @Qualifier
+                @FeatureFlag(
+                    key = "enable_continue_watching_nitro",
+                    title = "Progress Endpoint",
+                    description = "Use Trakt's internal /sync/progress/up_next_nitro call instead of the documented multi-step progress fetch.",
+                    defaultValue = false,
+                    dateAdded = "2026-05-20",
+                )
+                public annotation class ContinueWatchingNitroFlagQualifier
+
+                @Qualifier
+                @FeatureFlag(
+                    key = "simkl_login_enabled",
+                    title = "Simkl Login",
+                    description = "Show the Simkl login entry point on the settings screen.",
+                    defaultValue = false,
+                    dateAdded = "2026-05-17",
+                )
+                public annotation class SimklLoginFlagQualifier
+            """.trimIndent(),
+        )
+
+        val result = FeatureFlagTestRunner().run(sources)
+        assertEquals(
+            "Compilation failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+        )
+
+        val files = result.generatedFiles
+        assertEquals(
+            "Expected exactly 2 generated files, got ${files.keys}",
+            setOf("ContinueWatchingNitroFlagBinding.kt", "SimklLoginFlagBinding.kt"),
+            files.keys,
+        )
+
+        GoldenFileAssert.assertMatches(
+            "featureflag/multi",
+            "ContinueWatchingNitroFlagBinding.kt",
+            files.getValue("ContinueWatchingNitroFlagBinding.kt"),
+        )
+        GoldenFileAssert.assertMatches(
+            "featureflag/multi",
+            "SimklLoginFlagBinding.kt",
+            files.getValue("SimklLoginFlagBinding.kt"),
+        )
+    }
+}

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagSimpleTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagSimpleTest.kt
@@ -1,0 +1,53 @@
+package io.github.thomaskioko.codegen.featureflag
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import io.github.thomaskioko.codegen.processor.GoldenFileAssert
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCompilerApi::class)
+class FeatureFlagSimpleTest {
+
+    @Test
+    fun `should generate binding interface for one FeatureFlag-decorated qualifier`() {
+        val sources = FeatureFlagStubs.baseStubs.toMap() + mapOf(
+            "ContinueWatchingNitroFlagQualifier.kt" to """
+                package com.thomaskioko.tvmaniac.featureflags.flags
+
+                import dev.zacsweers.metro.Qualifier
+                import io.github.thomaskioko.codegen.annotations.FeatureFlag
+
+                @Qualifier
+                @FeatureFlag(
+                    key = "enable_continue_watching_nitro",
+                    title = "Progress Endpoint",
+                    description = "Use Trakt's internal /sync/progress/up_next_nitro call instead of the documented multi-step progress fetch.",
+                    defaultValue = false,
+                    dateAdded = "2026-05-20",
+                )
+                public annotation class ContinueWatchingNitroFlagQualifier
+            """.trimIndent(),
+        )
+
+        val result = FeatureFlagTestRunner().run(sources)
+        assertEquals(
+            "Compilation failed:\n${result.messages}",
+            KotlinCompilation.ExitCode.OK,
+            result.exitCode,
+        )
+
+        val files = result.generatedFiles
+        assertEquals(
+            "Expected exactly 1 generated file, got ${files.keys}",
+            setOf("ContinueWatchingNitroFlagBinding.kt"),
+            files.keys,
+        )
+
+        GoldenFileAssert.assertMatches(
+            "featureflag/simple",
+            "ContinueWatchingNitroFlagBinding.kt",
+            files.getValue("ContinueWatchingNitroFlagBinding.kt"),
+        )
+    }
+}

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagStubs.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagStubs.kt
@@ -1,0 +1,75 @@
+package io.github.thomaskioko.codegen.featureflag
+
+/**
+ * Minimal source-level fakes of the consumer project types the feature flag generator references.
+ *
+ * The processor resolves type names against whatever is on the test compilation's classpath, so
+ * each test must compile alongside source files that declare the consumer's `FeatureFlag` and
+ * `FeatureFlagFactory` interfaces, the Metro `Qualifier`/`AppScope`/`@Provides`/`@IntoSet`/`@SingleIn`/`@ContributesTo`
+ * annotations, and `kotlinx.datetime.LocalDate`. Bundling these as test sources rather than
+ * depending on the real consumer jars keeps the test module hermetic and lets the compiler type
+ * check the generated output in isolation.
+ *
+ * The type signatures here must match the constants in
+ * `codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/util/External.kt`
+ * exactly. If the consumer's primitives change, both files must be updated together.
+ */
+internal object FeatureFlagStubs {
+
+    val metroAnnotations = "MetroAnnotations.kt" to """
+        package dev.zacsweers.metro
+
+        import kotlin.reflect.KClass
+
+        public abstract class AppScope private constructor()
+
+        @Target(AnnotationTarget.ANNOTATION_CLASS)
+        public annotation class Qualifier
+
+        @Target(AnnotationTarget.CLASS)
+        public annotation class ContributesTo(val scope: KClass<*>)
+
+        @Target(AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+        public annotation class Provides
+
+        @Target(AnnotationTarget.FUNCTION)
+        public annotation class IntoSet
+
+        @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+        public annotation class SingleIn(val scope: KClass<*>)
+    """.trimIndent()
+
+    val kotlinxDatetime = "LocalDate.kt" to """
+        package kotlinx.datetime
+
+        public class LocalDate(
+            public val year: Int,
+            public val month: Int,
+            public val day: Int,
+        )
+    """.trimIndent()
+
+    val featureFlagApi = "FeatureFlag.kt" to """
+        package com.thomaskioko.tvmaniac.featureflags
+
+        import kotlinx.datetime.LocalDate
+
+        public interface FeatureFlag<T>
+
+        public interface FeatureFlagFactory {
+            public fun boolean(
+                key: String,
+                title: String,
+                description: String,
+                defaultValue: Boolean,
+                dateAdded: LocalDate,
+            ): FeatureFlag<Boolean>
+        }
+    """.trimIndent()
+
+    val baseStubs: List<Pair<String, String>> = listOf(
+        metroAnnotations,
+        kotlinxDatetime,
+        featureFlagApi,
+    )
+}

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagTestRunner.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagTestRunner.kt
@@ -1,0 +1,66 @@
+package io.github.thomaskioko.codegen.featureflag
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.kspProcessorOptions
+import com.tschuchort.compiletesting.kspSourcesDir
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import com.tschuchort.compiletesting.useKsp2
+import io.github.thomaskioko.codegen.featureflag.processor.FeatureFlagCodegenProcessorProvider
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import java.io.File
+
+/**
+ * Test harness that runs [io.github.thomaskioko.codegen.featureflag.processor.FeatureFlagCodegenProcessor]
+ * over inline Kotlin source strings and exposes the generated files for golden comparison.
+ *
+ * Mirrors the navigation `ProcessorTestRunner` shape. Each [run] call builds a fresh
+ * `KotlinCompilation` configured with KSP2, registers
+ * [FeatureFlagCodegenProcessorProvider] as the only symbol processor provider, compiles the
+ * supplied sources, and walks the KSP output directory to collect every generated `.kt` file.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+internal class FeatureFlagTestRunner {
+
+    /**
+     * The result of one processor run.
+     *
+     * @property result The raw compilation result. Error-path tests assert on [result.messages]
+     *   to verify the diagnostic format.
+     * @property generatedFiles The generated Kotlin files keyed by simple file name.
+     */
+    data class RunResult(
+        val result: JvmCompilationResult,
+        val generatedFiles: Map<String, String>,
+    ) {
+        val exitCode: KotlinCompilation.ExitCode get() = result.exitCode
+        val messages: String get() = result.messages
+    }
+
+    /**
+     * Compiles [sources] under KSP2 with [FeatureFlagCodegenProcessor] registered, then collects
+     * every generated Kotlin file.
+     */
+    fun run(sources: Map<String, String>): RunResult {
+        val compilation = KotlinCompilation().apply {
+            this.sources = sources.map { (name, content) -> SourceFile.kotlin(name, content) }
+            useKsp2()
+            symbolProcessorProviders = mutableListOf(FeatureFlagCodegenProcessorProvider())
+            kspProcessorOptions = mutableMapOf()
+            inheritClassPath = true
+            messageOutputStream = System.out
+        }
+
+        val result = compilation.compile()
+        val generated = collectGeneratedKotlinFiles(compilation.kspSourcesDir)
+        return RunResult(result = result, generatedFiles = generated)
+    }
+
+    private fun collectGeneratedKotlinFiles(root: File): Map<String, String> {
+        if (!root.exists()) return emptyMap()
+        return root.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .associate { file -> file.name to file.readText() }
+    }
+}

--- a/codegen/processor-test/src/test/resources/golden/featureflag/multi/ContinueWatchingNitroFlagBinding.kt
+++ b/codegen/processor-test/src/test/resources/golden/featureflag/multi/ContinueWatchingNitroFlagBinding.kt
@@ -1,0 +1,29 @@
+package com.thomaskioko.tvmaniac.featureflags.flags
+
+import com.thomaskioko.tvmaniac.featureflags.FeatureFlag
+import com.thomaskioko.tvmaniac.featureflags.FeatureFlagFactory
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import kotlin.Boolean
+import kotlinx.datetime.LocalDate
+
+@ContributesTo(AppScope::class)
+public interface ContinueWatchingNitroFlagBinding {
+  @Provides
+  @SingleIn(AppScope::class)
+  @ContinueWatchingNitroFlagQualifier
+  public fun provideContinueWatchingNitroFlag(factory: FeatureFlagFactory): FeatureFlag<Boolean> = factory.boolean(
+      key = "enable_continue_watching_nitro",
+      title = "Progress Endpoint",
+      description = "Use Trakt's internal /sync/progress/up_next_nitro call instead of the documented multi-step progress fetch.",
+      defaultValue = false,
+      dateAdded = LocalDate(2_026, 5, 20),
+  )
+
+  @Provides
+  @IntoSet
+  public fun bindContinueWatchingNitroFlag(@ContinueWatchingNitroFlagQualifier flag: FeatureFlag<Boolean>): FeatureFlag<Boolean> = flag
+}

--- a/codegen/processor-test/src/test/resources/golden/featureflag/multi/SimklLoginFlagBinding.kt
+++ b/codegen/processor-test/src/test/resources/golden/featureflag/multi/SimklLoginFlagBinding.kt
@@ -1,0 +1,29 @@
+package com.thomaskioko.tvmaniac.featureflags.flags
+
+import com.thomaskioko.tvmaniac.featureflags.FeatureFlag
+import com.thomaskioko.tvmaniac.featureflags.FeatureFlagFactory
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import kotlin.Boolean
+import kotlinx.datetime.LocalDate
+
+@ContributesTo(AppScope::class)
+public interface SimklLoginFlagBinding {
+  @Provides
+  @SingleIn(AppScope::class)
+  @SimklLoginFlagQualifier
+  public fun provideSimklLoginFlag(factory: FeatureFlagFactory): FeatureFlag<Boolean> = factory.boolean(
+      key = "simkl_login_enabled",
+      title = "Simkl Login",
+      description = "Show the Simkl login entry point on the settings screen.",
+      defaultValue = false,
+      dateAdded = LocalDate(2_026, 5, 17),
+  )
+
+  @Provides
+  @IntoSet
+  public fun bindSimklLoginFlag(@SimklLoginFlagQualifier flag: FeatureFlag<Boolean>): FeatureFlag<Boolean> = flag
+}

--- a/codegen/processor-test/src/test/resources/golden/featureflag/simple/ContinueWatchingNitroFlagBinding.kt
+++ b/codegen/processor-test/src/test/resources/golden/featureflag/simple/ContinueWatchingNitroFlagBinding.kt
@@ -1,0 +1,29 @@
+package com.thomaskioko.tvmaniac.featureflags.flags
+
+import com.thomaskioko.tvmaniac.featureflags.FeatureFlag
+import com.thomaskioko.tvmaniac.featureflags.FeatureFlagFactory
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import kotlin.Boolean
+import kotlinx.datetime.LocalDate
+
+@ContributesTo(AppScope::class)
+public interface ContinueWatchingNitroFlagBinding {
+  @Provides
+  @SingleIn(AppScope::class)
+  @ContinueWatchingNitroFlagQualifier
+  public fun provideContinueWatchingNitroFlag(factory: FeatureFlagFactory): FeatureFlag<Boolean> = factory.boolean(
+      key = "enable_continue_watching_nitro",
+      title = "Progress Endpoint",
+      description = "Use Trakt's internal /sync/progress/up_next_nitro call instead of the documented multi-step progress fetch.",
+      defaultValue = false,
+      dateAdded = LocalDate(2_026, 5, 20),
+  )
+
+  @Provides
+  @IntoSet
+  public fun bindContinueWatchingNitroFlag(@ContinueWatchingNitroFlagQualifier flag: FeatureFlag<Boolean>): FeatureFlag<Boolean> = flag
+}

--- a/codegen/settings.gradle.kts
+++ b/codegen/settings.gradle.kts
@@ -28,6 +28,8 @@ rootProject.name = "codegen"
 
 include(
     ":annotations",
+    ":featureflag-annotations",
     ":processor",
+    ":featureflag-processor",
     ":processor-test",
 )

--- a/gradle/publishing.properties
+++ b/gradle/publishing.properties
@@ -2,7 +2,7 @@
 # Composite-specific overrides (POM_NAME, POM_DESCRIPTION) stay in each
 # composite's own gradle.properties.
 GROUP=io.github.thomaskioko.gradle.plugins
-VERSION_NAME=0.8.0
+VERSION_NAME=0.9.0
 INCEPTION_YEAR=2025
 
 POM_REPO_NAME=app-gradle-plugins

--- a/gradle/publishing.properties
+++ b/gradle/publishing.properties
@@ -2,7 +2,7 @@
 # Composite-specific overrides (POM_NAME, POM_DESCRIPTION) stay in each
 # composite's own gradle.properties.
 GROUP=io.github.thomaskioko.gradle.plugins
-VERSION_NAME=0.7.9
+VERSION_NAME=0.8.0
 INCEPTION_YEAR=2025
 
 POM_REPO_NAME=app-gradle-plugins

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/TvManiacRuleSetProvider.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/TvManiacRuleSetProvider.kt
@@ -4,6 +4,7 @@ import com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
 import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
 import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
 import io.github.thomaskioko.gradle.plugins.lint.codegen.ComposeScreenCodegenAnnotationRule
+import io.github.thomaskioko.gradle.plugins.lint.codegen.NoManualNavBindingRule
 import io.github.thomaskioko.gradle.plugins.lint.codegen.PresenterCodegenAnnotationRule
 import io.github.thomaskioko.gradle.plugins.lint.metro.MetroRedundantInjectRule
 import io.github.thomaskioko.gradle.plugins.lint.navigation.NoCustomNavigatorInterfaceRule
@@ -38,6 +39,10 @@ import io.github.thomaskioko.gradle.plugins.lint.tests.TestNameFormatRule
  *   requires every `@Composable` function with a presenter parameter to carry `@ScreenUi`,
  *   `@SheetUi`, or `@AppRootUi` so the codegen processor wires it into the renderer
  *   multibinding.
+ * - [NoManualNavBindingRule] (`tvmaniac:no-manual-nav-binding`) forbids hand-written
+ *   `@Provides @IntoSet` providers for `NavRoot`, `NavRootBinding`, `NavDestination`, or
+ *   `NavRouteBinding`. Codegen owns those multibindings whenever a presenter is annotated with
+ *   `@NavDestination` or `@AppRoot`.
  * - [TestNameFormatRule] (`tvmaniac:test-name-format`) enforces the `should X given Y` test
  *   naming convention.
  *
@@ -54,6 +59,7 @@ public class TvManiacRuleSetProvider : RuleSetProviderV3(RuleSetId(RULE_SET_ID))
         RuleProvider { MetroRedundantInjectRule() },
         RuleProvider { PresenterCodegenAnnotationRule() },
         RuleProvider { ComposeScreenCodegenAnnotationRule() },
+        RuleProvider { NoManualNavBindingRule() },
     )
 
     private companion object {

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/NoManualNavBindingRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/NoManualNavBindingRule.kt
@@ -1,0 +1,108 @@
+package io.github.thomaskioko.gradle.plugins.lint.codegen
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.ElementType.FUN
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleAutocorrectApproveHandler
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import io.github.thomaskioko.gradle.plugins.lint.RULE_ABOUT
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtNullableType
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
+
+/**
+ * Forbids hand-written `@Provides @IntoSet` providers for navigation types that the codegen
+ * processor already emits.
+ *
+ * The codegen module generates a `<Feature>NavDestinationBinding` or `<Feature>TabDestinationBinding`
+ * container for every presenter annotated with `@NavDestination` or `@AppRoot`. These containers
+ * own the `@IntoSet` contributions for `Set<NavRoot>`, `Set<NavRootBinding<*>>`,
+ * `Set<NavDestination<*>>`, and `Set<NavRouteBinding<*>>`. Any hand-written `@Provides @IntoSet`
+ * returning one of those four types duplicates the generated provider and creates Metro multibinding
+ * conflicts or silent drift when the codegen surface changes.
+ *
+ * The rule fires on any function declaration that carries both `@Provides` and `@IntoSet` (in any
+ * order) and whose declared return type's short name matches one of the four nav types. The fix is
+ * to delete the manual provider (and usually the wrapper `@ContributesTo` interface that contains
+ * it) and add `@NavDestination` or `@AppRoot` to the sibling presenter if it is missing.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * // Forbidden:
+ * @ContributesTo(ActivityScope::class)
+ * interface ProgressRootBinding {
+ *     companion object {
+ *         @Provides
+ *         @IntoSet
+ *         fun provideProgressRoot(): NavRoot = ProgressRoot
+ *     }
+ * }
+ *
+ * // Allowed: annotate the presenter and let the processor emit the binding.
+ * @NavDestination(
+ *     route = ProgressRoute::class,
+ *     parentScope = ActivityScope::class,
+ *     kind = DestinationKind.TAB_ROOT,
+ * )
+ * @Inject
+ * class ProgressPresenter(...)
+ * ```
+ */
+public class NoManualNavBindingRule :
+    Rule(
+        ruleId = RuleId("tvmaniac:no-manual-nav-binding"),
+        about = RULE_ABOUT,
+    ),
+    RuleAutocorrectApproveHandler {
+    override fun beforeVisitChildNodes(
+        node: ASTNode,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> AutocorrectDecision,
+    ) {
+        if (node.elementType != FUN) return
+
+        val ktFunction = node.psi as? KtNamedFunction ?: return
+
+        val annotationNames = ktFunction.annotationEntries
+            .mapNotNullTo(mutableSetOf()) { it.shortName?.asString() }
+        if (PROVIDES_ANNOTATION !in annotationNames) return
+        if (INTO_SET_ANNOTATION !in annotationNames) return
+
+        val returnTypeShortName = ktFunction.typeReference?.shortName() ?: return
+        if (returnTypeShortName !in FORBIDDEN_RETURN_TYPES) return
+
+        val functionName = ktFunction.name ?: "<unnamed>"
+        emit(node.startOffset, errorMessage(returnTypeShortName, functionName), false)
+    }
+
+    private fun KtTypeReference.shortName(): String? {
+        val element = typeElement ?: return null
+        val userType = when (element) {
+            is KtUserType -> element
+            is KtNullableType -> element.innerType as? KtUserType
+            else -> null
+        } ?: return null
+        return userType.referencedName
+    }
+
+    public companion object {
+        internal const val PROVIDES_ANNOTATION: String = "Provides"
+        internal const val INTO_SET_ANNOTATION: String = "IntoSet"
+
+        internal val FORBIDDEN_RETURN_TYPES: Set<String> = setOf(
+            "NavRoot",
+            "NavRootBinding",
+            "NavDestination",
+            "NavRouteBinding",
+        )
+
+        internal fun errorMessage(returnTypeShortName: String, functionName: String): String =
+            "`$functionName` provides `$returnTypeShortName` into a multibinding that the codegen " +
+                "processor already populates. Delete this manual `@Provides @IntoSet` provider (and " +
+                "its wrapper `@ContributesTo` interface if it becomes empty). If the sibling presenter " +
+                "is missing `@NavDestination` or `@AppRoot`, add the codegen annotation instead of " +
+                "hand-writing the binding."
+    }
+}

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/NoManualNavBindingRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/NoManualNavBindingRuleTest.kt
@@ -1,0 +1,212 @@
+package io.github.thomaskioko.gradle.plugins.lint.codegen
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import org.junit.jupiter.api.Test
+
+class NoManualNavBindingRuleTest {
+    private val assertThat = assertThatRule { NoManualNavBindingRule() }
+
+    @Test
+    fun `should flag provider given Provides IntoSet returning NavRoot`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @ContributesTo(ActivityScope::class)
+            interface ProgressRootBinding {
+                companion object {
+                    @Provides
+                    @IntoSet
+                    fun provideProgressRoot(): NavRoot = ProgressRoot
+                }
+            }
+            """.trimIndent(),
+        ).hasLintViolationWithoutAutoCorrect(
+            line = 6,
+            col = 9,
+            detail = NoManualNavBindingRule.errorMessage("NavRoot", "provideProgressRoot"),
+        )
+    }
+
+    @Test
+    fun `should flag provider given Provides IntoSet returning NavRootBinding`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @ContributesTo(ActivityScope::class)
+            interface ProgressRootBinding {
+                companion object {
+                    @Provides
+                    @IntoSet
+                    fun provideProgressRootBinding(): NavRootBinding<*> =
+                        NavRootBinding(ProgressRoot::class, ProgressRoot.serializer())
+                }
+            }
+            """.trimIndent(),
+        ).hasLintViolationWithoutAutoCorrect(
+            line = 6,
+            col = 9,
+            detail = NoManualNavBindingRule.errorMessage("NavRootBinding", "provideProgressRootBinding"),
+        )
+    }
+
+    @Test
+    fun `should flag provider given Provides IntoSet returning NavDestination`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @ContributesTo(ActivityScope::class)
+            interface GenreShowsNavDestinationBinding {
+                companion object {
+                    @Provides
+                    @IntoSet
+                    fun provideGenreShowsNavDestination(): NavDestination<*> = NavDestination.Screen(
+                        routeClass = GenreShowsRoute::class,
+                    ) { _, _ -> GenreShowsDestination }
+                }
+            }
+            """.trimIndent(),
+        ).hasLintViolationWithoutAutoCorrect(
+            line = 6,
+            col = 9,
+            detail = NoManualNavBindingRule.errorMessage("NavDestination", "provideGenreShowsNavDestination"),
+        )
+    }
+
+    @Test
+    fun `should flag provider given Provides IntoSet returning NavRouteBinding`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @ContributesTo(ActivityScope::class)
+            interface GenreShowsNavDestinationBinding {
+                companion object {
+                    @Provides
+                    @IntoSet
+                    fun provideGenreShowsRouteBinding(): NavRouteBinding<*> =
+                        NavRouteBinding(GenreShowsRoute::class, GenreShowsRoute.serializer())
+                }
+            }
+            """.trimIndent(),
+        ).hasLintViolationWithoutAutoCorrect(
+            line = 6,
+            col = 9,
+            detail = NoManualNavBindingRule.errorMessage("NavRouteBinding", "provideGenreShowsRouteBinding"),
+        )
+    }
+
+    @Test
+    fun `should flag provider given IntoSet annotation precedes Provides`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @ContributesTo(ActivityScope::class)
+            interface LibraryRootBinding {
+                companion object {
+                    @IntoSet
+                    @Provides
+                    fun provideLibraryRoot(): NavRoot = LibraryRoot
+                }
+            }
+            """.trimIndent(),
+        ).hasLintViolationWithoutAutoCorrect(
+            line = 6,
+            col = 9,
+            detail = NoManualNavBindingRule.errorMessage("NavRoot", "provideLibraryRoot"),
+        )
+    }
+
+    @Test
+    fun `should flag provider given top-level Provides IntoSet function`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @Provides
+            @IntoSet
+            fun provideStrayNavRoot(): NavRoot = StrayRoot
+            """.trimIndent(),
+        ).hasLintViolationWithoutAutoCorrect(
+            line = 3,
+            col = 1,
+            detail = NoManualNavBindingRule.errorMessage("NavRoot", "provideStrayNavRoot"),
+        )
+    }
+
+    @Test
+    fun `should not flag provider given Provides IntoSet returning unrelated type`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @ContributesTo(ActivityScope::class)
+            interface DebugNotificationInitializerBindingContainer {
+                companion object {
+                    @Provides
+                    @IntoSet
+                    fun provideInitializer(): Initializer = DebugInitializer
+                }
+            }
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `should not flag provider given Provides without IntoSet`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @ContributesTo(ActivityScope::class)
+            interface SomeContainer {
+                companion object {
+                    @Provides
+                    fun provideRoot(): NavRoot = SomeRoot
+                }
+            }
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `should not flag provider given IntoSet without Provides`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            @ContributesTo(ActivityScope::class)
+            interface SomeContainer {
+                companion object {
+                    @IntoSet
+                    fun provideRoot(): NavRoot = SomeRoot
+                }
+            }
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+
+    @Test
+    fun `should not flag function given no annotations even when returning NavRoot`() {
+        assertThat(
+            // language=kotlin
+            """
+            package test
+
+            fun describeNavRoot(): NavRoot = SomeRoot
+            """.trimIndent(),
+        ).hasNoLintViolations()
+    }
+}

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/RootPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/RootPlugin.kt
@@ -110,12 +110,6 @@ public abstract class RootPlugin : Plugin<Project> {
             analysis.useTypesafeProjectAccessors(true)
 
             analysis.issues { issues ->
-                AnalysisExclusions.ignoredModules.forEach { projectPath ->
-                    issues.project(projectPath) { project ->
-                        project.onAny { issue -> issue.severity("ignore") }
-                    }
-                }
-
                 issues.all { project ->
                     project.onAny {
                         it.severity("fail")

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/analysis/AnalysisExclusions.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/analysis/AnalysisExclusions.kt
@@ -88,10 +88,6 @@ internal object AnalysisExclusions {
         "io.kotest:kotest-assertions-shared",
     )
 
-    val ignoredModules: List<String> = listOf(
-        ":ios-framework",
-    )
-
     // KMP test source sets where DAGP's "incorrect configuration" advice produces
     // api(...) recommendations that Kotlin warns are unsupported and slated for removal.
     val ignoredIncorrectConfigurationSourceSets: List<String> = listOf(

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
@@ -2,6 +2,7 @@ package io.github.thomaskioko.gradle.plugins.extensions
 
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import com.android.build.api.dsl.Lint
+import com.autonomousapps.DependencyAnalysisExtension
 import io.github.thomaskioko.gradle.plugins.setup.setupCodegen
 import io.github.thomaskioko.gradle.plugins.setup.setupKotlinInject
 import io.github.thomaskioko.gradle.plugins.setup.setupMetro
@@ -44,6 +45,68 @@ import java.net.URI
  */
 @ScaffoldDsl
 public abstract class BaseExtension(private val project: Project) : ExtensionAware {
+    /**
+     * Silences DAGP's "unused dependencies" check for the named Gradle project paths.
+     *
+     * The call routes to the root project's `DependencyAnalysisExtension`, so each named module's
+     * unused-dependency analysis output is suppressed regardless of which scaffold the call lives
+     * in. Appropriate when a module contributes Metro bindings into a consumer's graph via
+     * `@ContributesBinding` codegen on Kotlin/Native targets, or any other compile-time
+     * contribution mechanism that DAGP cannot trace via JVM/Android bytecode.
+     *
+     * ```kotlin
+     * scaffold {
+     *   ignoreUnused(":data:request-manager:testing")
+     * }
+     * ```
+     *
+     * @param projectPaths Gradle project paths (for example `":data:request-manager:testing"`)
+     *   whose unused-dependency analysis output should be silenced.
+     */
+    public fun ignoreUnused(vararg projectPaths: String) {
+        project.rootProject.extensions.configure(DependencyAnalysisExtension::class.java) { analysis ->
+            analysis.issues { issues ->
+                projectPaths.forEach { projectPath ->
+                    issues.project(projectPath) { perProject ->
+                        perProject.onUnusedDependencies { it.severity("ignore") }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Silences every DAGP issue category (`onAny`) for the named Gradle project paths. Use
+     * sparingly.
+     *
+     * The call routes to the root project's `DependencyAnalysisExtension`, so the named module's
+     * analysis output is suppressed regardless of which scaffold the call lives in. Appropriate
+     * for a Kotlin/Native-only framework module whose dependencies are entirely consumed by the
+     * iOS app and never by another JVM or Android consumer, where DAGP's model genuinely does
+     * not apply. Replaces the previous hardcoded `AnalysisExclusions.ignoredModules` list with
+     * an explicit per-module opt-in.
+     *
+     * ```kotlin
+     * scaffold {
+     *   ignoreAll(":ios-framework")
+     * }
+     * ```
+     *
+     * @param projectPaths Gradle project paths (for example `":ios-framework"`) whose DAGP
+     *   analysis output should be silenced.
+     */
+    public fun ignoreAll(vararg projectPaths: String) {
+        project.rootProject.extensions.configure(DependencyAnalysisExtension::class.java) { analysis ->
+            analysis.issues { issues ->
+                projectPaths.forEach { projectPath ->
+                    issues.project(projectPath) { perProject ->
+                        perProject.onAny { it.severity("ignore") }
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * Adds compiler opt-in entries to every Kotlin compilation in the project.
      *

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
@@ -4,6 +4,7 @@ import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import com.android.build.api.dsl.Lint
 import com.autonomousapps.DependencyAnalysisExtension
 import io.github.thomaskioko.gradle.plugins.setup.setupCodegen
+import io.github.thomaskioko.gradle.plugins.setup.setupFeatureFlagCodegen
 import io.github.thomaskioko.gradle.plugins.setup.setupKotlinInject
 import io.github.thomaskioko.gradle.plugins.setup.setupMetro
 import io.github.thomaskioko.gradle.plugins.setup.setupSerialization
@@ -200,6 +201,30 @@ public abstract class BaseExtension(private val project: Project) : ExtensionAwa
      */
     public fun useCodegen() {
         project.setupCodegen()
+    }
+
+    /**
+     * Applies KSP and adds the feature flag codegen processor and annotations.
+     *
+     * The codegen reads `@FeatureFlag`-decorated qualifier annotations and emits one
+     * `<QualifierBaseName>Binding.kt` per qualifier into the qualifier's package. Each generated
+     * file contains a `@ContributesTo(AppScope::class)` interface with two `@Provides` methods that
+     * wire the flag through the consumer's `FeatureFlagFactory` and into the
+     * `Set<FeatureFlag<Boolean>>` multibinding. See `codegen/docs/featureflag.md` for the full
+     * contract.
+     *
+     * Independent from [useCodegen]; modules that consume both navigation and feature flag codegen
+     * call both functions.
+     *
+     * ```kotlin
+     * scaffold {
+     *   useMetro()
+     *   useFeatureFlagCodegen()
+     * }
+     * ```
+     */
+    public fun useFeatureFlagCodegen() {
+        project.setupFeatureFlagCodegen()
     }
 
     /**

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/FeatureFlagCodegenSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/FeatureFlagCodegenSetup.kt
@@ -1,0 +1,27 @@
+package io.github.thomaskioko.gradle.plugins.setup
+
+import io.github.thomaskioko.gradle.plugins.utils.addImplementationDependency
+import io.github.thomaskioko.gradle.plugins.utils.addKspDependencyForCommonMain
+import io.github.thomaskioko.gradle.plugins.utils.getDependency
+import org.gradle.api.Project
+
+/**
+ * Wires the feature flag codegen tier into a consumer module.
+ *
+ * Resolves `codegen-featureflag-annotations` and `codegen-featureflag-processor` from the
+ * consumer's version catalog, registers the processor against `kspCommonMain`, and adds the
+ * annotation jar to `commonMainImplementation`. Applies Metro first when absent, since the
+ * generated bindings reference `@Provides`, `@ContributesTo`, and `@SingleIn` from
+ * `dev.zacsweers.metro`.
+ *
+ * Mirrors [setupCodegen] for the navigation tier — same shape, different artifact aliases.
+ */
+internal fun Project.setupFeatureFlagCodegen() {
+    if (!plugins.hasPlugin("dev.zacsweers.metro")) {
+        setupMetro()
+    }
+
+    setupKsp()
+    addImplementationDependency(getDependency("codegen-featureflag-annotations"))
+    addKspDependencyForCommonMain(getDependency("codegen-featureflag-processor"))
+}


### PR DESCRIPTION
## Description
This PR introduces a new feature flag code generation system to automate the creation of feature flag bindings and simplifies the integration process. It also adds a custom lint rule to enforce the use of these generated bindings by detecting and discouraging manual navigation bindings.

## Changes
- **Feature Flag Codegen**: Introduced `featureflag-annotations` and `featureflag-processor` modules to automate feature flag binding generation via KSP.
- **Navigation Lint Rule**: Added a new lint rule to detect manual navigation bindings, ensuring developers leverage the codegen system.
- **Refactored Dependency Analysis**: Updated dependency analysis exclusions to use a more maintainable DSL-based configuration.
