### PR TITLE
App plugin improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+## 0.8.2 *(2026-06-20)*
+
+- Clean up experimental Kotlin compiler flags. Remove the `-Xannotation-default-target`, `-Xcontext-parameters`, `-Xannotation-target-all`, `-Xallow-reified-type-in-catch`, and `-Xexplicit-backing-fields` compiler flags now that these features are stable in Kotlin 2.4. Passing them had become redundant and made every consumer module emit a `redundant for the current language version 2.4` warning on each compile task. Projects that pin `kotlin-language` below 2.4 can pass any flag they still need directly.
+- Rename `ignoreUnused()` to `ignoreUnusedDependencies()` (breaking) and scope it to exclude the named project dependencies from the calling module's unused-dependency check, instead of silencing the named modules' own analysis output. This lets `scaffold { ignoreUnusedDependencies(...) }` stand in for a hand-written project-scoped `configure<DependencyAnalysisSubExtension>` block when a module declares a dependency as `api(...)` for downstream consumers (for example integration-test fixtures) that its own sources never reference.
+
 ## 0.8.1 *(2026-06-20)*
 
 - `ignoreAll()` now defaults to the project it is called from when no path is passed, so a bare `ignoreAll()` inside a module's `scaffold {}` block silences that module's dependency analysis. The empty vararg previously silenced nothing, which left framework umbrella modules such as `ios-framework` flagged for every dependency the iOS application consumes across the Objective-C boundary.

--- a/gradle/publishing.properties
+++ b/gradle/publishing.properties
@@ -2,7 +2,7 @@
 # Composite-specific overrides (POM_NAME, POM_DESCRIPTION) stay in each
 # composite's own gradle.properties.
 GROUP=io.github.thomaskioko.gradle.plugins
-VERSION_NAME=0.8.1
+VERSION_NAME=0.8.2
 INCEPTION_YEAR=2025
 
 POM_REPO_NAME=app-gradle-plugins

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BasePlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BasePlugin.kt
@@ -138,25 +138,13 @@ public abstract class BasePlugin : Plugin<Project> {
                 progressiveMode.set(version >= KotlinVersion.Companion.DEFAULT)
 
                 freeCompilerArgs.addAll(
-                    "-Xannotation-default-target=param-property",
                     // https://kotlinlang.org/docs/whatsnew2020.html#data-class-copy-function-to-have-the-same-visibility-as-constructor
                     "-Xconsistent-data-class-copy-visibility",
-                    // Enable 2.2.0 feature previews
-                    "-Xcontext-parameters",
                     "-Xcontext-sensitive-resolution",
-                    // Enable using @all:... annotation use site target
-                    // https://kotlinlang.org/docs/annotations.html#all-meta-target
-                    "-Xannotation-target-all",
                     // Enable unused return value checks for annotated methods
                     // TODO: change to full which changes it from opt-out by adding @IgnorableReturnValue instead of opt-in by adding @MustUseReturnValues
                     // https://kotlinlang.org/docs/whatsnew23.html#unused-return-value-checker
                     "-Xreturn-value-checker=check",
-                    // Makes it possible to use reified exception types in catch clauses
-                    // https://kotlinlang.org/docs/whatsnew2220.html#support-for-reified-types-in-catch-clauses
-                    "-Xallow-reified-type-in-catch",
-                    // opt in to experimental apis
-                    // https://kotlinlang.org/docs/whatsnew23.html#explicit-backing-fields
-                    "-Xexplicit-backing-fields",
                     "-opt-in=kotlin.time.ExperimentalTime",
                     "-opt-in=kotlin.uuid.ExperimentalUuidApi",
                 )

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
@@ -47,30 +47,29 @@ import java.net.URI
 @ScaffoldDsl
 public abstract class BaseExtension(private val project: Project) : ExtensionAware {
     /**
-     * Silences DAGP's "unused dependencies" check for the named Gradle project paths.
+     * Excludes the named project dependencies from this module's "unused dependencies" check.
      *
-     * The call routes to the root project's `DependencyAnalysisExtension`, so each named module's
-     * unused-dependency analysis output is suppressed regardless of which scaffold the call lives
-     * in. Appropriate when a module contributes Metro bindings into a consumer's graph via
-     * `@ContributesBinding` codegen on Kotlin/Native targets, or any other compile-time
-     * contribution mechanism that DAGP cannot trace via JVM/Android bytecode.
+     * The call routes to the root project's `DependencyAnalysisExtension` and scopes the exclusion
+     * to the module the scaffold is attached to, replacing a hand-written project-scoped
+     * `configure<DependencyAnalysisSubExtension> { issues { onUnusedDependencies { exclude(...) } } }`
+     * block. Appropriate when a module declares a dependency as `api(...)` for downstream consumers
+     * (for example integration-test fixtures) that its own sources never reference, so the analysis
+     * reports the dependency as unused.
      *
      * ```kotlin
      * scaffold {
-     *   ignoreUnused(":data:request-manager:testing")
+     *   ignoreUnusedDependencies(":data:request-manager:testing")
      * }
      * ```
      *
-     * @param projectPaths Gradle project paths (for example `":data:request-manager:testing"`)
-     *   whose unused-dependency analysis output should be silenced.
+     * @param dependencyPaths Gradle project dependency paths (for example
+     *   `":data:request-manager:testing"`) to exclude from this module's unused-dependency check.
      */
-    public fun ignoreUnused(vararg projectPaths: String) {
+    public fun ignoreUnusedDependencies(vararg dependencyPaths: String) {
         project.rootProject.extensions.configure(DependencyAnalysisExtension::class.java) { analysis ->
             analysis.issues { issues ->
-                projectPaths.forEach { projectPath ->
-                    issues.project(projectPath) { perProject ->
-                        perProject.onUnusedDependencies { it.severity("ignore") }
-                    }
+                issues.project(project.path) { perProject ->
+                    perProject.onUnusedDependencies { it.exclude(*dependencyPaths) }
                 }
             }
         }


### PR DESCRIPTION
## Description
- Clean up experimental Kotlin compiler flags. Remove the `-Xannotation-default-target`, `-Xcontext-parameters`, `-Xannotation-target-all`, `-Xallow-reified-type-in-catch`, and `-Xexplicit-backing-fields` compiler flags now that these features are stable in Kotlin 2.4. Passing them had become redundant and made every consumer module emit a `redundant for the current language version 2.4` warning on each compile task. Projects that pin `kotlin-language` below 2.4 can pass any flag they still need directly.
- Rename `ignoreUnused()` to `ignoreUnusedDependencies()` (breaking) and scope it to exclude the named project dependencies from the calling module's unused-dependency check, instead of silencing the named modules' own analysis output. This lets `scaffold { ignoreUnusedDependencies(...) }` stand in for a hand-written project-scoped `configure<DependencyAnalysisSubExtension>` block when a module declares a dependency as `api(...)` for downstream consumers (for example integration-test fixtures) that its own sources never reference.
