### PR TITLE
Add the Apache license and format the whole codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+## 0.8.6
+
+- Add the Apache 2.0 license text at the repository root. Every published POM declared `The Apache Software License, Version 2.0` but the license itself was never committed, so GitHub reported the project as unlicensed.
+
 ## 0.8.5 *(2026-07-24)*
 
 - Attach the Android host-test task to the `linuxTest` aggregate. `KotlinMultiplatformPlugin` wired variant test tasks by iterating `KotlinTargetWithTests`, but the AGP Kotlin Multiplatform android target does not implement that interface, so a module whose suite lived only in `androidHostTest` never reached the aggregate and its tests went unrun on CI while the job still reported green. The plugin now attaches `testAndroidHostTest` for any module that has a `src/androidHostTest` source set. Modules carrying only `commonTest` are deliberately left out: those tests already run on the jvm target, and repeating them on the Android host adds runtime without adding coverage. Consumers need no change, though a module that had dark `androidHostTest` tests will start running them, so expect the aggregate to take longer and to surface failures that were previously hidden. Locked in by a functional test that asserts the dependency edge through `linuxTest --dry-run` rather than only checking that the task resolves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Change Log
 ## 0.8.6
 
 - Add the Apache 2.0 license text at the repository root. Every published POM declared `The Apache Software License, Version 2.0` but the license itself was never committed, so GitHub reported the project as unlicensed.
+- Add the Apache license header to every Kotlin source file, so the published sources carry it too. `plugins` and `lint-rules` applied the Spotless plugin without declaring a format block, and the aggregate check reached codegen's build scripts but none of its modules, so most of the repository was never formatted or checked.
 
 ## 0.8.5 *(2026-07-24)*
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+ Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.publish) apply false
@@ -42,7 +57,7 @@ tasks.register("spotlessApplyAll") {
     dependsOn("spotlessApply")
     dependsOn(gradle.includedBuild("plugins").task(":spotlessApply"))
     dependsOn(gradle.includedBuild("lint-rules").task(":spotlessApply"))
-    dependsOn(gradle.includedBuild("codegen").task(":spotlessApply"))
+    dependsOn(gradle.includedBuild("codegen").task(":spotlessApplyAll"))
 }
 
 tasks.register("spotlessCheckAll") {
@@ -51,5 +66,5 @@ tasks.register("spotlessCheckAll") {
     dependsOn("spotlessCheck")
     dependsOn(gradle.includedBuild("plugins").task(":spotlessCheck"))
     dependsOn(gradle.includedBuild("lint-rules").task(":spotlessCheck"))
-    dependsOn(gradle.includedBuild("codegen").task(":spotlessCheck"))
+    dependsOn(gradle.includedBuild("codegen").task(":spotlessCheckAll"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,16 @@ plugins {
     alias(libs.plugins.app.spotless)
 }
 
+spotless {
+    kotlinGradle {
+        target("*.kts")
+        licenseHeaderFile(
+            rootProject.file("spotless/spotless.kt"),
+            "(import|plugins|pluginManagement|dependencyResolutionManagement)",
+        )
+    }
+}
+
 tasks.register("publishLocal") {
     group = "publishing"
     description = "Publish plugins + codegen artifacts to mavenLocal."

--- a/codegen/annotations/build.gradle.kts
+++ b/codegen/annotations/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.publish)

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/AppRoot.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/AppRoot.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.annotations
 
 import kotlin.reflect.KClass

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/AppRootUi.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/AppRootUi.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.annotations
 
 import kotlin.reflect.KClass

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/ChildPresenter.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/ChildPresenter.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.annotations
 
 import kotlin.reflect.KClass

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/NavDestination.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/NavDestination.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.annotations
 
 import kotlin.reflect.KClass

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/ScreenUi.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/ScreenUi.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.annotations
 
 import kotlin.reflect.KClass

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/SheetUi.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/SheetUi.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.annotations
 
 import kotlin.reflect.KClass

--- a/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/TabUi.kt
+++ b/codegen/annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/TabUi.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.annotations
 
 import kotlin.reflect.KClass

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import com.diffplug.gradle.spotless.SpotlessExtension
 
 plugins {
@@ -18,6 +33,20 @@ spotless {
         target("*.kts")
         licenseHeaderFile(licenseHeader, ktsLicenseDelimiter)
     }
+}
+
+tasks.register("spotlessApplyAll") {
+    group = "formatting"
+    description = "Run spotlessApply on this build and every module in it."
+    dependsOn("spotlessApply")
+    dependsOn(subprojects.map { "${it.path}:spotlessApply" })
+}
+
+tasks.register("spotlessCheckAll") {
+    group = "verification"
+    description = "Run spotlessCheck on this build and every module in it."
+    dependsOn("spotlessCheck")
+    dependsOn(subprojects.map { "${it.path}:spotlessCheck" })
 }
 
 subprojects {

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -9,11 +9,14 @@ plugins {
 }
 
 val ktlintVersion = libs.versions.ktlint.get()
+val licenseHeader = rootProject.file("../spotless/spotless.kt")
+val ktsLicenseDelimiter = "(import|plugins|pluginManagement|dependencyResolutionManagement)"
 
 spotless {
     kotlinGradle {
         ktlint(ktlintVersion)
         target("*.kts")
+        licenseHeaderFile(licenseHeader, ktsLicenseDelimiter)
     }
 }
 
@@ -29,10 +32,12 @@ subprojects {
             ktlint(ktlintVersion).editorConfigOverride(mapOf("android" to "true"))
             target("src/**/*.kt")
             targetExclude("**/resources/**", "**/build/**")
+            licenseHeaderFile(licenseHeader)
         }
         kotlinGradle {
             ktlint(ktlintVersion)
             target("*.kts")
+            licenseHeaderFile(licenseHeader, ktsLicenseDelimiter)
         }
     }
 }

--- a/codegen/featureflag-annotations/build.gradle.kts
+++ b/codegen/featureflag-annotations/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.publish)

--- a/codegen/featureflag-annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/FeatureFlag.kt
+++ b/codegen/featureflag-annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/FeatureFlag.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.annotations
 
 /**

--- a/codegen/featureflag-annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/Platform.kt
+++ b/codegen/featureflag-annotations/src/commonMain/kotlin/io/github/thomaskioko/codegen/annotations/Platform.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.annotations
 
 /**

--- a/codegen/featureflag-processor/build.gradle.kts
+++ b/codegen/featureflag-processor/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagBindingGenerator.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagBindingGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag.processor
 
 import com.squareup.kotlinpoet.AnnotationSpec

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagCodegenProcessor.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagCodegenProcessor.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag.processor
 
 import com.google.devtools.ksp.processing.CodeGenerator

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagCodegenProcessorProvider.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagCodegenProcessorProvider.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag.processor
 
 import com.google.devtools.ksp.processing.SymbolProcessor

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagData.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagData.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag.processor
 
 import com.squareup.kotlinpoet.ClassName

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagQualifierGenerator.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/FeatureFlagQualifierGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag.processor
 
 import com.squareup.kotlinpoet.AnnotationSpec

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/PlatformSourceSetGuard.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/PlatformSourceSetGuard.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag.processor
 
 import com.google.devtools.ksp.processing.JvmPlatformInfo

--- a/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/util/External.kt
+++ b/codegen/featureflag-processor/src/main/kotlin/io/github/thomaskioko/codegen/featureflag/processor/util/External.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag.processor.util
 
 import com.squareup.kotlinpoet.ClassName

--- a/codegen/processor-test/build.gradle.kts
+++ b/codegen/processor-test/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagErrorPathTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagErrorPathTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagMultiFlagTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagMultiFlagTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagPlatformCaseTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagPlatformCaseTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagSimpleTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagSimpleTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagStubs.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagStubs.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag
 
 /**

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagTestRunner.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/featureflag/FeatureFlagTestRunner.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.featureflag
 
 import com.tschuchort.compiletesting.JvmCompilationResult

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/AppRootTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/AppRootTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/AppRootUiTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/AppRootUiTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/ChildPresenterTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/ChildPresenterTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/ErrorPathTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/ErrorPathTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/GoldenFileAssert.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/GoldenFileAssert.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import org.junit.Assert.assertEquals

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/NavDestinationTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/NavDestinationTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/ProcessorTestRunner.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/ProcessorTestRunner.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.tschuchort.compiletesting.JvmCompilationResult

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/ScreenUiTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/ScreenUiTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/SheetUiTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/SheetUiTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/TabUiTest.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/TabUiTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.tschuchort.compiletesting.KotlinCompilation

--- a/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/TestStubs.kt
+++ b/codegen/processor-test/src/test/kotlin/io/github/thomaskioko/codegen/processor/TestStubs.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 /**

--- a/codegen/processor/build.gradle.kts
+++ b/codegen/processor/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/Constants.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/Constants.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 /**

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessor.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessor.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.google.devtools.ksp.processing.CodeGenerator

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessorProvider.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessorProvider.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor
 
 import com.google.devtools.ksp.processing.SymbolProcessor

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/AppRootBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/AppRootBindingGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.codegen
 
 import com.squareup.kotlinpoet.CodeBlock

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/AppRootUiBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/AppRootUiBindingGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.codegen
 
 import com.squareup.kotlinpoet.AnnotationSpec

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/BindingFiles.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/BindingFiles.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.codegen
 
 import com.squareup.kotlinpoet.ClassName

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/ChildGraphGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/ChildGraphGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.codegen
 
 import com.squareup.kotlinpoet.FileSpec

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/FileGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/FileGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.codegen
 
 import com.squareup.kotlinpoet.FileSpec

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/NavDestinationBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/NavDestinationBindingGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.codegen
 
 import com.squareup.kotlinpoet.ClassName

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/ScreenGraphGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/ScreenGraphGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.codegen
 
 import com.squareup.kotlinpoet.FileSpec

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/TabDestinationBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/TabDestinationBindingGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.codegen
 
 import com.squareup.kotlinpoet.CodeBlock

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/UiBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/UiBindingGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.codegen
 
 import com.squareup.kotlinpoet.ClassName

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/AppRootData.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/AppRootData.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.data
 
 import com.squareup.kotlinpoet.ClassName

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/ChildPresenterData.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/ChildPresenterData.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.data
 
 import com.squareup.kotlinpoet.ClassName

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/NavData.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/NavData.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.data
 
 import com.squareup.kotlinpoet.ClassName

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/UiBindingData.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/data/UiBindingData.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.data
 
 import com.squareup.kotlinpoet.ClassName

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AnnotationArguments.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AnnotationArguments.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.parser
 
 import com.google.devtools.ksp.symbol.KSAnnotation

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AppRootParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AppRootParser.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.parser
 
 import com.google.devtools.ksp.processing.KSPLogger

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AppRootUiParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/AppRootUiParser.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.parser
 
 import com.google.devtools.ksp.processing.KSPLogger

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/ChildPresenterParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/ChildPresenterParser.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.parser
 
 import com.google.devtools.ksp.processing.KSPLogger

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/NavDestinationParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/NavDestinationParser.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.parser
 
 import com.google.devtools.ksp.processing.KSPLogger

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/UiParser.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/parser/UiParser.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.parser
 
 import com.google.devtools.ksp.processing.KSPLogger

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/External.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/External.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.util
 
 import com.squareup.kotlinpoet.ClassName

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/KotlinPoet.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/KotlinPoet.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.codegen.processor.util
 
 import com.squareup.kotlinpoet.AnnotationSpec

--- a/codegen/settings.gradle.kts
+++ b/codegen/settings.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 pluginManagement {
     includeBuild("../build-logic")
 }

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -14,6 +14,23 @@ base {
 group = property("GROUP").toString()
 version = property("VERSION_NAME").toString()
 
+val ktlintVersion = libs.versions.ktlint.get()
+val licenseHeader = rootProject.file("../spotless/spotless.kt")
+
+spotless {
+    kotlin {
+        ktlint(ktlintVersion).editorConfigOverride(mapOf("android" to "true"))
+        target("src/**/*.kt")
+        targetExclude("**/resources/**", "**/build/**")
+        licenseHeaderFile(licenseHeader)
+    }
+    kotlinGradle {
+        ktlint(ktlintVersion)
+        target("*.kts")
+        licenseHeaderFile(licenseHeader, "(import|plugins|pluginManagement|dependencyResolutionManagement)")
+    }
+}
+
 kotlin {
     explicitApi()
     jvmToolchain(libs.versions.java.toolchain.get().toInt())

--- a/lint-rules/settings.gradle.kts
+++ b/lint-rules/settings.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 pluginManagement {
     includeBuild("../build-logic")
 }

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/RuleMetadata.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/RuleMetadata.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint
 
 import com.pinterest.ktlint.rule.engine.core.api.Rule

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/TvManiacRuleSetProvider.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/TvManiacRuleSetProvider.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint
 
 import com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/CodegenExemptions.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/CodegenExemptions.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.codegen
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CommaSeparatedListValueParser

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/NoManualNavBindingRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/NoManualNavBindingRule.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.codegen
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/PresenterCodegenAnnotationRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/PresenterCodegenAnnotationRule.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.codegen
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
@@ -8,8 +23,8 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import io.github.thomaskioko.gradle.plugins.lint.RULE_ABOUT
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
 
 /**
  * Requires every presenter class injected by Metro to also carry a codegen annotation that wires

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/metro/MetroRedundantInjectRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/metro/MetroRedundantInjectRule.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.metro
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NavigationModulePaths.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NavigationModulePaths.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.navigation
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CommaSeparatedListValueParser

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoCustomNavigatorInterfaceRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoCustomNavigatorInterfaceRule.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.navigation
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoMutatingRouterImportRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoMutatingRouterImportRule.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.navigation
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoNavigationConstructOutsideNavRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoNavigationConstructOutsideNavRule.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.navigation
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/preview/NoStyleWrapperInPreviewRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/preview/NoStyleWrapperInPreviewRule.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.preview
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/preview/PreviewWrappers.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/preview/PreviewWrappers.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.preview
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CommaSeparatedListValueParser

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/tests/TestNameFormatRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/tests/TestNameFormatRule.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.tests
 
 import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/NoManualNavBindingRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/NoManualNavBindingRuleTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.codegen
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/PresenterCodegenAnnotationRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/PresenterCodegenAnnotationRuleTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.codegen
 
 import com.pinterest.ktlint.rule.engine.api.Code
@@ -5,10 +20,10 @@ import com.pinterest.ktlint.rule.engine.api.KtLintRuleEngine
 import com.pinterest.ktlint.rule.engine.api.LintError
 import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
-import java.io.File
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.io.File
 
 class PresenterCodegenAnnotationRuleTest {
     private val assertThat = assertThatRule { PresenterCodegenAnnotationRule() }

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/metro/MetroRedundantInjectRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/metro/MetroRedundantInjectRuleTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.metro
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoCustomNavigatorInterfaceRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoCustomNavigatorInterfaceRuleTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.navigation
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoMutatingRouterImportRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoMutatingRouterImportRuleTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.navigation
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoNavigationConstructOutsideNavRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoNavigationConstructOutsideNavRuleTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.navigation
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/preview/NoStyleWrapperInPreviewRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/preview/NoStyleWrapperInPreviewRuleTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.preview
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule

--- a/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/tests/TestNameFormatRuleTest.kt
+++ b/lint-rules/src/test/kotlin/io/github/thomaskioko/gradle/plugins/lint/tests/TestNameFormatRuleTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.lint.tests
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -13,6 +13,23 @@ plugins {
 group = property("GROUP").toString()
 version = property("VERSION_NAME").toString()
 
+val ktlintVersion = libs.versions.ktlint.get()
+val licenseHeader = rootProject.file("../spotless/spotless.kt")
+
+spotless {
+    kotlin {
+        ktlint(ktlintVersion).editorConfigOverride(mapOf("android" to "true"))
+        target("src/**/*.kt")
+        targetExclude("**/resources/**", "**/build/**")
+        licenseHeaderFile(licenseHeader)
+    }
+    kotlinGradle {
+        ktlint(ktlintVersion)
+        target("*.kts")
+        licenseHeaderFile(licenseHeader, "(import|plugins|pluginManagement|dependencyResolutionManagement)")
+    }
+}
+
 val functionalTest = sourceSets.create("functionalTest")
 
 configurations[functionalTest.implementationConfigurationName]

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.gradle.api.tasks.testing.Test
 import org.gradle.plugin.devel.tasks.PluginUnderTestMetadata
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -37,18 +52,19 @@ configurations[functionalTest.implementationConfigurationName]
 configurations[functionalTest.runtimeOnlyConfigurationName]
     .extendsFrom(configurations.testRuntimeOnly.get())
 
-val functionalTestTask = tasks.register<Test>("functionalTest") {
-    description = "Runs functional tests via Gradle TestKit against the built plugin classpath."
-    group = "verification"
-    testClassesDirs = functionalTest.output.classesDirs
-    classpath = functionalTest.runtimeClasspath
-    useJUnit()
-    shouldRunAfter(tasks.named("test"))
-    systemProperty(
-        "io.github.thomaskioko.gradle.plugins.fixtures.dir",
-        file("src/functionalTest/resources/fixtures").absolutePath,
-    )
-}
+val functionalTestTask =
+    tasks.register<Test>("functionalTest") {
+        description = "Runs functional tests via Gradle TestKit against the built plugin classpath."
+        group = "verification"
+        testClassesDirs = functionalTest.output.classesDirs
+        classpath = functionalTest.runtimeClasspath
+        useJUnit()
+        shouldRunAfter(tasks.named("test"))
+        systemProperty(
+            "io.github.thomaskioko.gradle.plugins.fixtures.dir",
+            file("src/functionalTest/resources/fixtures").absolutePath,
+        )
+    }
 
 val testPluginExtras: Configuration by configurations.creating {
     isCanBeConsumed = false
@@ -76,7 +92,7 @@ tasks {
             allWarningsAsErrors.set(false)
             freeCompilerArgs.addAll(
                 "-opt-in=kotlin.RequiresOptIn",
-                "-Xjvm-default=all"
+                "-Xjvm-default=all",
             )
         }
     }

--- a/plugins/settings.gradle.kts
+++ b/plugins/settings.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 pluginManagement {
     includeBuild("../build-logic")
 }

--- a/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/AppPluginFunctionalTest.kt
+++ b/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/AppPluginFunctionalTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.functional
 
 import org.gradle.testkit.runner.TaskOutcome

--- a/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/FixtureProject.kt
+++ b/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/FixtureProject.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.functional
 
 import org.gradle.testkit.runner.GradleRunner
@@ -8,7 +23,12 @@ internal class FixtureProject(val rootDir: File) {
         GradleRunner.create()
             .withProjectDir(rootDir)
             .withPluginClasspath()
-            .withArguments(buildList { addAll(args.asList()); add("--stacktrace") })
+            .withArguments(
+                buildList {
+                    addAll(args.asList())
+                    add("--stacktrace")
+                },
+            )
             .forwardOutput()
 }
 

--- a/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/JvmPluginFunctionalTest.kt
+++ b/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/JvmPluginFunctionalTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.functional
 
 import org.gradle.testkit.runner.TaskOutcome

--- a/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/KmpPluginFunctionalTest.kt
+++ b/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/KmpPluginFunctionalTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.functional
 
 import org.gradle.testkit.runner.TaskOutcome

--- a/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/RootPluginRequiredFunctionalTest.kt
+++ b/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/RootPluginRequiredFunctionalTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.functional
 
 import org.junit.Assert.assertTrue

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/AndroidPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/AndroidPlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins
 
 import com.android.build.api.dsl.ApplicationDefaultConfig
@@ -92,7 +107,7 @@ public abstract class AndroidPlugin : Plugin<Project> {
             onVariants { variant ->
                 if (variant.buildType == "debug") {
                     rootProject.tasks.named(BasePlugin.LINUX_TEST).configure { task ->
-                        task.dependsOn("${path}:test${variant.name.capitalizeFirst()}UnitTest")
+                        task.dependsOn("$path:test${variant.name.capitalizeFirst()}UnitTest")
                     }
                 }
             }

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/AppPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/AppPlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins
 
 import io.github.thomaskioko.gradle.plugins.extensions.AppExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BasePlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BasePlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins
 
 import io.github.thomaskioko.gradle.plugins.extensions.BaseExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BaselineProfilePlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BaselineProfilePlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins
 
 import androidx.baselineprofile.gradle.producer.BaselineProfileProducerExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BuildConfigGeneratorPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/BuildConfigGeneratorPlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins
 
 import io.github.thomaskioko.gradle.plugins.extensions.BuildConfigExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/JvmPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/JvmPlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins
 
 import io.github.thomaskioko.gradle.plugins.extensions.JvmExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/KotlinMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/KotlinMultiplatformPlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins
 
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
@@ -7,6 +22,7 @@ import io.github.thomaskioko.gradle.plugins.setup.configureCommonAndroid
 import io.github.thomaskioko.gradle.plugins.setup.setupTests
 import io.github.thomaskioko.gradle.plugins.utils.addIfNotNull
 import io.github.thomaskioko.gradle.plugins.utils.androidComponents
+import io.github.thomaskioko.gradle.plugins.utils.capitalizeFirst
 import io.github.thomaskioko.gradle.plugins.utils.compilerOptions
 import io.github.thomaskioko.gradle.plugins.utils.disableMultiplatformTasks
 import io.github.thomaskioko.gradle.plugins.utils.getDependencyOrNull
@@ -17,7 +33,6 @@ import io.github.thomaskioko.gradle.tasks.CopyMokoResourceBundlesTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
-import io.github.thomaskioko.gradle.plugins.utils.capitalizeFirst
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
@@ -150,7 +165,7 @@ public abstract class KotlinMultiplatformPlugin : Plugin<Project> {
                         }
                         val testTaskName = "${target.name}${compilation.name.capitalizeFirst()}"
                         rootProject.tasks.named(aggregateTaskName).configure {
-                            it.dependsOn("${path}:$testTaskName")
+                            it.dependsOn("$path:$testTaskName")
                         }
                     }
                 }

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/ResourceGeneratorPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/ResourceGeneratorPlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins
 
 import io.github.thomaskioko.gradle.tasks.MokoResourceGeneratorTask

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/RootPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/RootPlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins
 
 import com.autonomousapps.DependencyAnalysisExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/RootPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/RootPlugin.kt
@@ -76,36 +76,24 @@ public abstract class RootPlugin : Plugin<Project> {
         pluginManager.withPlugin("com.osacky.doctor") {
             extensions.configure(DoctorExtension::class.java) { doctor ->
                 with(doctor) {
-                    /**
-                     * Do not allow building all apps simultaneously. This is likely not what the user intended.
-                     */
+                    // Do not allow building all apps simultaneously. This is likely not what the user intended.
                     allowBuildingAllAndroidAppsSimultaneously.set(false)
 
-                    /**
-                     * Warn if using Android Jetifier. It slows down builds.
-                     */
+                    // Warn if using Android Jetifier. It slows down builds.
                     warnWhenJetifierEnabled.set(true)
 
-                    /**
-                     * The level at which to warn when a build spends more than this percent garbage collecting.
-                     */
+                    // The level at which to warn when a build spends more than this percent garbage collecting.
                     GCWarningThreshold.set(0.10f)
 
                     javaHome { handler ->
                         with(handler) {
-                            /**
-                             * Ensure that we are using JAVA_HOME to build with this Gradle.
-                             */
+                            // Ensure that we are using JAVA_HOME to build with this Gradle.
                             ensureJavaHomeMatches.set(true)
 
-                            /**
-                             * Ensure we have JAVA_HOME set.
-                             */
+                            // Ensure we have JAVA_HOME set.
                             ensureJavaHomeIsSet.set(true)
 
-                            /**
-                             * Fail on any `JAVA_HOME` issues.
-                             */
+                            // Fail on any `JAVA_HOME` issues.
                             failOnError.set(scaffoldProperties().javaToolchainsStrict)
                         }
                     }

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/analysis/AnalysisExclusions.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/analysis/AnalysisExclusions.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.analysis
 
 /**

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/checks/LintPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/checks/LintPlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.checks
 
 import org.gradle.api.GradleException
@@ -46,6 +61,7 @@ public class LintPlugin : Plugin<Project> {
 
     private fun Project.addLintRulesArtifact(coordinates: String) {
         val extra = extensions.extraProperties
+
         @Suppress("UNCHECKED_CAST")
         val current: List<String> = if (extra.has(SpotlessPlugin.CUSTOM_RULE_SETS_KEY)) {
             (extra.get(SpotlessPlugin.CUSTOM_RULE_SETS_KEY) as? List<String>).orEmpty()

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/checks/SpotlessPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/checks/SpotlessPlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.checks
 
 import com.diffplug.gradle.spotless.SpotlessExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/AndroidExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/AndroidExtension.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.extensions
 
 import androidx.baselineprofile.gradle.consumer.BaselineProfileConsumerExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/AppExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/AppExtension.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.extensions
 
 import io.github.thomaskioko.gradle.plugins.setup.setupFirebase

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BaseExtension.kt
@@ -1,12 +1,27 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.extensions
 
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import com.android.build.api.dsl.Lint
 import com.autonomousapps.DependencyAnalysisExtension
 import io.github.thomaskioko.gradle.plugins.setup.setupCodegen
+import io.github.thomaskioko.gradle.plugins.setup.setupDependencyGuard
 import io.github.thomaskioko.gradle.plugins.setup.setupFeatureFlagCodegen
 import io.github.thomaskioko.gradle.plugins.setup.setupKotlinInject
-import io.github.thomaskioko.gradle.plugins.setup.setupDependencyGuard
 import io.github.thomaskioko.gradle.plugins.setup.setupMetro
 import io.github.thomaskioko.gradle.plugins.setup.setupSerialization
 import io.github.thomaskioko.gradle.plugins.utils.compilerOptions

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BuildConfigExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/BuildConfigExtension.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.extensions
 
 import org.gradle.api.Project

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/FrameworkExtensions.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/FrameworkExtensions.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.extensions
 
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/JvmExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/JvmExtension.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.extensions
 
 import io.github.thomaskioko.gradle.plugins.setup.setupStandaloneLint

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/ModuleGraphExtension.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/ModuleGraphExtension.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.extensions
 
 import org.gradle.api.provider.Property

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/ScaffoldDsl.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/extensions/ScaffoldDsl.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.extensions
 
 /**

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/graph/Graph.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/graph/Graph.kt
@@ -1,7 +1,21 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.graph
 
 import io.github.thomaskioko.gradle.plugins.extensions.ModuleGraphExtension
-import java.io.Serializable
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
@@ -15,6 +29,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
+import java.io.Serializable
 import kotlin.text.RegexOption.DOT_MATCHES_ALL
 
 /**

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/properties/PropertyKeys.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/properties/PropertyKeys.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.properties
 
 internal object PropertyKeys {

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/properties/ScaffoldProperties.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/properties/ScaffoldProperties.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.properties
 
 import io.github.thomaskioko.gradle.plugins.utils.booleanProperty

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/AndroidTestSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/AndroidTestSetup.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import com.android.build.api.dsl.TestExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/CodegenSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/CodegenSetup.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import io.github.thomaskioko.gradle.plugins.utils.addImplementationDependency

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/ComposeSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/ComposeSetup.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import io.github.thomaskioko.gradle.plugins.properties.scaffoldProperties

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/FeatureFlagCodegenSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/FeatureFlagCodegenSetup.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import io.github.thomaskioko.gradle.plugins.utils.addImplementationDependency

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/FirebaseSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/FirebaseSetup.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/KotlinInjectSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/KotlinInjectSetup.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import io.github.thomaskioko.gradle.plugins.utils.addBundleImplementationDependency

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/KspSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/KspSetup.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import com.google.devtools.ksp.gradle.KspExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/LintSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/LintSetup.kt
@@ -1,12 +1,27 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import com.android.build.api.dsl.Lint
 import io.github.thomaskioko.gradle.plugins.utils.addIfNotNull
 import io.github.thomaskioko.gradle.plugins.utils.android
 import io.github.thomaskioko.gradle.plugins.utils.getBundleDependenciesOrNull
 import io.github.thomaskioko.gradle.plugins.utils.getVersion
 import io.github.thomaskioko.gradle.plugins.utils.pathBasedAndroidNamespace
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/MetroSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/MetroSetup.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import dev.zacsweers.metro.gradle.ExperimentalMetroGradleApi

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/SerializationSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/SerializationSetup.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import io.github.thomaskioko.gradle.plugins.utils.addImplementationDependency

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/SetupDependencyGuard.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/SetupDependencyGuard.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPluginExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/TestSetup.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/setup/TestSetup.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.setup
 
 import org.gradle.api.tasks.testing.Test

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/AndroidDisableTasks.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/AndroidDisableTasks.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.utils
 
 import org.gradle.api.Project

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/DependencyExtensions.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/DependencyExtensions.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.utils
 
 import org.gradle.api.Project

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/DisableTasksCore.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/DisableTasksCore.kt
@@ -3,16 +3,6 @@ package io.github.thomaskioko.gradle.plugins.utils
 import com.android.build.api.variant.AndroidComponentsExtension
 import org.gradle.api.Project
 
-/**
- * Task-disabling primitives shared by `AndroidDisableTasks`, `KmpDisableTasks`, and
- * `JvmDisableTasks`. Compatible with AGP 8.3+.
- *
- * Design principles:
- * - Preserves task graph integrity using `onlyIf { false }`
- * - Tolerates missing tasks via `tasks.configureEach` filtering rather than `tasks.named`
- * - Skips processing during IDE sync to prevent configuration issues
- */
-
 /** Default variant to keep active during debug-only builds. */
 internal const val DEFAULT_ACTIVE_VARIANT: String = "debug"
 

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/DisableTasksCore.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/DisableTasksCore.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.utils
 
 import com.android.build.api.variant.AndroidComponentsExtension

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/Extensions.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/Extensions.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.utils
 
 import com.android.build.api.dsl.ApplicationExtension
@@ -137,7 +152,9 @@ internal fun Project.java(block: JavaPluginExtension.() -> Unit) {
 internal fun KotlinProjectExtension.compilerOptions(configure: KotlinCommonCompilerOptions.() -> Unit) {
     when (this) {
         is KotlinJvmProjectExtension -> compilerOptions(configure)
+
         is KotlinAndroidProjectExtension -> compilerOptions(configure)
+
         is KotlinMultiplatformExtension -> {
             compilerOptions(configure)
             targets.configureEach { target ->

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/GradlePropertiesExtensions.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/GradlePropertiesExtensions.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.utils
 
 import io.github.thomaskioko.gradle.plugins.properties.scaffoldProperties

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/JvmDisableTasks.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/JvmDisableTasks.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.utils
 
 import org.gradle.api.Project

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/KmpDisableTasks.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/KmpDisableTasks.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.utils
 
 import org.gradle.api.Project

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/VersionCatalog.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/VersionCatalog.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.utils
 
 import org.gradle.api.JavaVersion

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/Versioning.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/Versioning.kt
@@ -1,48 +1,63 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.utils
 
 public object Versioning {
 
-  public val VERSION_REGEX: Regex = Regex("""VERSION_NUMBER\s*=\s*(\S+)""")
-  public val BUILD_REGEX: Regex = Regex("""BUILD_NUMBER\s*=\s*(\S+)""")
+    public val VERSION_REGEX: Regex = Regex("""VERSION_NUMBER\s*=\s*(\S+)""")
+    public val BUILD_REGEX: Regex = Regex("""BUILD_NUMBER\s*=\s*(\S+)""")
 
-  public fun compute(versionName: String): Int {
-    val (major, minor, patch) = parseSemver(versionName)
-    require(major in 0..209) { "Major version must be 0-209, got: $major" }
-    require(minor in 0..99) { "Minor version must be 0-99, got: $minor" }
-    require(patch in 0..99) { "Patch version must be 0-99, got: $patch" }
-    val result = (major * 10_000_000) + (minor * 100_000) + (patch * 1_000)
-    require(result in 0..Int.MAX_VALUE) { "Version code overflow: $versionName produces $result" }
-    return result
-  }
-
-  public fun bump(versionName: String, bumpType: String): String {
-    val (major, minor, patch) = parseSemver(versionName)
-    val (newMajor, newMinor, newPatch) = when (bumpType) {
-      "major" -> Triple(major + 1, 0, 0)
-      "minor" -> Triple(major, minor + 1, 0)
-      "patch" -> Triple(major, minor, patch + 1)
-      else -> throw IllegalArgumentException("bumpType must be major, minor, or patch, got: $bumpType")
+    public fun compute(versionName: String): Int {
+        val (major, minor, patch) = parseSemver(versionName)
+        require(major in 0..209) { "Major version must be 0-209, got: $major" }
+        require(minor in 0..99) { "Minor version must be 0-99, got: $minor" }
+        require(patch in 0..99) { "Patch version must be 0-99, got: $patch" }
+        val result = (major * 10_000_000) + (minor * 100_000) + (patch * 1_000)
+        require(result in 0..Int.MAX_VALUE) { "Version code overflow: $versionName produces $result" }
+        return result
     }
-    val newVersion = "$newMajor.$newMinor.$newPatch"
-    validateSemver(newVersion)
-    return newVersion
-  }
 
-  private fun validateSemver(versionName: String) {
-    val (major, minor, patch) = parseSemver(versionName)
-    require(major in 0..209) { "Major version must be 0-209, got: $major" }
-    require(minor in 0..99) { "Minor version must be 0-99, got: $minor" }
-    require(patch in 0..99) { "Patch version must be 0-99, got: $patch" }
-  }
-
-  private fun parseSemver(versionName: String): Triple<Int, Int, Int> {
-    val parts = versionName.split(".")
-    require(parts.size == 3) { "Version must be in major.minor.patch format, got: $versionName" }
-    val (major, minor, patch) = parts.map {
-      it.toIntOrNull() ?: throw IllegalArgumentException(
-        "Version components must be integers, got: '$it' in '$versionName'",
-      )
+    public fun bump(versionName: String, bumpType: String): String {
+        val (major, minor, patch) = parseSemver(versionName)
+        val (newMajor, newMinor, newPatch) = when (bumpType) {
+            "major" -> Triple(major + 1, 0, 0)
+            "minor" -> Triple(major, minor + 1, 0)
+            "patch" -> Triple(major, minor, patch + 1)
+            else -> throw IllegalArgumentException("bumpType must be major, minor, or patch, got: $bumpType")
+        }
+        val newVersion = "$newMajor.$newMinor.$newPatch"
+        validateSemver(newVersion)
+        return newVersion
     }
-    return Triple(major, minor, patch)
-  }
+
+    private fun validateSemver(versionName: String) {
+        val (major, minor, patch) = parseSemver(versionName)
+        require(major in 0..209) { "Major version must be 0-209, got: $major" }
+        require(minor in 0..99) { "Minor version must be 0-99, got: $minor" }
+        require(patch in 0..99) { "Patch version must be 0-99, got: $patch" }
+    }
+
+    private fun parseSemver(versionName: String): Triple<Int, Int, Int> {
+        val parts = versionName.split(".")
+        require(parts.size == 3) { "Version must be in major.minor.patch format, got: $versionName" }
+        val (major, minor, patch) = parts.map {
+            it.toIntOrNull() ?: throw IllegalArgumentException(
+                "Version components must be integers, got: '$it' in '$versionName'",
+            )
+        }
+        return Triple(major, minor, patch)
+    }
 }

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/BuildConfigGeneratorTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/BuildConfigGeneratorTask.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.tasks
 
 import com.squareup.kotlinpoet.FileSpec

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/CopyMokoResourceBundlesTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/CopyMokoResourceBundlesTask.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.tasks
 
 import org.gradle.api.file.FileCollection

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTask.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.tasks
 
 import com.squareup.kotlinpoet.ClassName

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/BumpVersionTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/BumpVersionTask.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.tasks.release
 
 import io.github.thomaskioko.gradle.plugins.utils.Versioning
@@ -12,62 +27,62 @@ import org.gradle.api.tasks.UntrackedTask
 @UntrackedTask(because = "Modifies version.txt in place")
 public abstract class BumpVersionTask : DefaultTask() {
 
-  init {
-    description = "Bumps VERSION_NUMBER (major/minor/patch/beta) and updates BUILD_NUMBER in version.txt"
-    group = "versioning"
-  }
-
-  @get:Internal
-  public abstract val versionFile: RegularFileProperty
-
-  @get:Input
-  public abstract val bumpType: Property<String>
-
-  @TaskAction
-  public fun bump() {
-    val file = versionFile.get().asFile
-    require(file.exists()) { "version.txt not found at ${file.path}" }
-
-    val content = file.readText()
-    val versionMatch = Versioning.VERSION_REGEX.find(content)
-      ?: error("VERSION_NUMBER not found in ${file.path}")
-    val currentVersion = versionMatch.groupValues[1]
-
-    val buildMatch = Versioning.BUILD_REGEX.find(content)
-      ?: error("BUILD_NUMBER not found in ${file.path}")
-    val currentBuild = buildMatch.groupValues[1].toIntOrNull()
-      ?: error("BUILD_NUMBER is not a valid integer in ${file.path}")
-
-    val type = bumpType.get()
-
-    if (type == "beta") {
-      val baseBuild = Versioning.compute(currentVersion)
-      require(currentBuild >= baseBuild) {
-        "BUILD_NUMBER ($currentBuild) is less than the base for version $currentVersion ($baseBuild). " +
-          "Run 'bumpVersion -Ptype=patch' to reset, or fix version.txt manually."
-      }
-      val newBuild = currentBuild + 1
-      val maxBuild = baseBuild + 999
-      require(newBuild <= maxBuild) {
-        "Beta number exceeded 999 for version $currentVersion. Bump patch/minor/major to continue."
-      }
-
-      val updated = content
-        .replace(Versioning.BUILD_REGEX, "BUILD_NUMBER = $newBuild")
-      file.writeText(updated)
-
-      val betaIteration = newBuild - baseBuild
-      logger.lifecycle("$currentVersion beta $betaIteration (BUILD_NUMBER = $currentBuild -> $newBuild)")
-    } else {
-      val newVersion = Versioning.bump(currentVersion, type)
-      val newBuild = Versioning.compute(newVersion)
-
-      val updated = content
-        .replace(Versioning.VERSION_REGEX, "VERSION_NUMBER = $newVersion")
-        .replace(Versioning.BUILD_REGEX, "BUILD_NUMBER = $newBuild")
-      file.writeText(updated)
-
-      logger.lifecycle("$currentVersion -> $newVersion (BUILD_NUMBER = $newBuild)")
+    init {
+        description = "Bumps VERSION_NUMBER (major/minor/patch/beta) and updates BUILD_NUMBER in version.txt"
+        group = "versioning"
     }
-  }
+
+    @get:Internal
+    public abstract val versionFile: RegularFileProperty
+
+    @get:Input
+    public abstract val bumpType: Property<String>
+
+    @TaskAction
+    public fun bump() {
+        val file = versionFile.get().asFile
+        require(file.exists()) { "version.txt not found at ${file.path}" }
+
+        val content = file.readText()
+        val versionMatch = Versioning.VERSION_REGEX.find(content)
+            ?: error("VERSION_NUMBER not found in ${file.path}")
+        val currentVersion = versionMatch.groupValues[1]
+
+        val buildMatch = Versioning.BUILD_REGEX.find(content)
+            ?: error("BUILD_NUMBER not found in ${file.path}")
+        val currentBuild = buildMatch.groupValues[1].toIntOrNull()
+            ?: error("BUILD_NUMBER is not a valid integer in ${file.path}")
+
+        val type = bumpType.get()
+
+        if (type == "beta") {
+            val baseBuild = Versioning.compute(currentVersion)
+            require(currentBuild >= baseBuild) {
+                "BUILD_NUMBER ($currentBuild) is less than the base for version $currentVersion ($baseBuild). " +
+                    "Run 'bumpVersion -Ptype=patch' to reset, or fix version.txt manually."
+            }
+            val newBuild = currentBuild + 1
+            val maxBuild = baseBuild + 999
+            require(newBuild <= maxBuild) {
+                "Beta number exceeded 999 for version $currentVersion. Bump patch/minor/major to continue."
+            }
+
+            val updated = content
+                .replace(Versioning.BUILD_REGEX, "BUILD_NUMBER = $newBuild")
+            file.writeText(updated)
+
+            val betaIteration = newBuild - baseBuild
+            logger.lifecycle("$currentVersion beta $betaIteration (BUILD_NUMBER = $currentBuild -> $newBuild)")
+        } else {
+            val newVersion = Versioning.bump(currentVersion, type)
+            val newBuild = Versioning.compute(newVersion)
+
+            val updated = content
+                .replace(Versioning.VERSION_REGEX, "VERSION_NUMBER = $newVersion")
+                .replace(Versioning.BUILD_REGEX, "BUILD_NUMBER = $newBuild")
+            file.writeText(updated)
+
+            logger.lifecycle("$currentVersion -> $newVersion (BUILD_NUMBER = $newBuild)")
+        }
+    }
 }

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/ReleaseTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/ReleaseTask.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.tasks.release
 
 import com.github.ajalt.mordant.terminal.ConversionResult
@@ -20,479 +35,479 @@ import javax.inject.Inject
 
 @UntrackedTask(because = "Modifies version.txt, CHANGELOG.md and creates git commit + tag")
 public abstract class ReleaseTask @Inject constructor(
-  private val execOperations: ExecOperations,
+    private val execOperations: ExecOperations,
 ) : DefaultTask() {
 
-  init {
-    description = "Bumps version, updates changelog, commits, and tags. Pass -Pi for interactive mode."
-    group = "versioning"
-  }
-
-  @get:Internal
-  public abstract val versionFile: RegularFileProperty
-
-  @get:Internal
-  public abstract val changelogFile: RegularFileProperty
-
-  @get:Internal
-  public abstract val cliffConfigFile: RegularFileProperty
-
-  @get:Internal
-  public abstract val projectDir: DirectoryProperty
-
-  @get:Input
-  public abstract val bumpType: Property<String>
-
-  @get:Input
-  public abstract val beta: Property<Boolean>
-
-  @get:Input
-  public abstract val interactive: Property<Boolean>
-
-  @get:Input
-  public abstract val dryRun: Property<Boolean>
-
-  @TaskAction
-  public fun release() {
-    requireGitCliff()
-
-    if (interactive.get()) {
-      runInteractive()
-    } else {
-      val validTypes = setOf("major", "minor", "patch", "beta")
-      require(bumpType.get() in validTypes) {
-        "Invalid bump type '${bumpType.get()}'. Must be one of: ${validTypes.joinToString()}"
-      }
-      runSilent()
-    }
-  }
-
-  private fun runSilent() {
-    val file = versionFile.get().asFile
-    require(file.exists()) { "version.txt not found at ${file.path}" }
-
-    val content = file.readText()
-    val currentVersion = parseVersion(content, file.path)
-    val currentBuild = parseBuildNumber(content, file.path)
-    val type = bumpType.get()
-    val isBetaBump = type == "beta"
-    val branch = currentBranch()
-
-    if (isBetaBump) {
-      val baseBuild = Versioning.compute(currentVersion)
-      require(currentBuild >= baseBuild) {
-        "BUILD_NUMBER ($currentBuild) is less than the base for version $currentVersion ($baseBuild). " +
-          "Run 'bumpVersion -Ptype=patch' to reset, or fix version.txt manually."
-      }
-      val newBuild = currentBuild + 1
-      require(newBuild <= baseBuild + 999) {
-        "Beta number exceeded 999 for version $currentVersion. Bump patch/minor/major to continue."
-      }
-
-      if (dryRun.get()) {
-        logger.lifecycle("$currentVersion beta (BUILD_NUMBER = $currentBuild -> $newBuild)")
-        logger.lifecycle("Dry run complete. No files modified, no commits created.")
-        return
-      }
-
-      writeVersionFile(file, content, currentVersion, newBuild)
-      git("add", file.absolutePath)
-      git("commit", "-m", "chore: bump beta build number to $newBuild")
-      git("push", "origin", branch)
-
-      logger.lifecycle("$currentVersion beta (BUILD_NUMBER = $currentBuild -> $newBuild)")
-      logger.lifecycle("Pushed to origin/$branch.")
-      return
+    init {
+        description = "Bumps version, updates changelog, commits, and tags. Pass -Pi for interactive mode."
+        group = "versioning"
     }
 
-    val isBeta = beta.get()
-    val newVersion = Versioning.bump(currentVersion, type)
-    val newBuild = Versioning.compute(newVersion)
-    val tag = buildTag(newVersion, isBeta, branch)
+    @get:Internal
+    public abstract val versionFile: RegularFileProperty
 
-    runChecks(file.toRelativeString(projectDir.get().asFile), tag, isBeta, branch) { label, block ->
-      block()
-    }
+    @get:Internal
+    public abstract val changelogFile: RegularFileProperty
 
-    val recentTags = recentReleaseTags()
-    if (recentTags.isNotEmpty()) {
-      logger.lifecycle("Recent releases: ${recentTags.joinToString(", ")}")
-    }
+    @get:Internal
+    public abstract val cliffConfigFile: RegularFileProperty
 
-    if (dryRun.get()) {
-      printDryRun(currentVersion, newVersion, tag)
-      return
-    }
+    @get:Internal
+    public abstract val projectDir: DirectoryProperty
 
-    writeVersionFile(file, content, newVersion, newBuild)
+    @get:Input
+    public abstract val bumpType: Property<String>
 
-    val changelog = changelogFile.get().asFile
-    generateChangelog(changelog, tag)
+    @get:Input
+    public abstract val beta: Property<Boolean>
 
-    git("add", file.absolutePath)
-    git("add", changelog.absolutePath)
-    git("commit", "-m", "release: $tag")
-    git("tag", "-a", tag, "-m", "Release $tag")
-    git("push", "origin", branch, "--tags")
+    @get:Input
+    public abstract val interactive: Property<Boolean>
 
-    logger.lifecycle("$currentVersion -> $newVersion (BUILD_NUMBER = $newBuild)")
-    logger.lifecycle("Pushed $tag to origin/$branch.")
-  }
+    @get:Input
+    public abstract val dryRun: Property<Boolean>
 
-  private fun runInteractive() {
-    val terminal = Terminal()
-    val file = versionFile.get().asFile
-    require(file.exists()) { "version.txt not found at ${file.path}" }
+    @TaskAction
+    public fun release() {
+        requireGitCliff()
 
-    val content = file.readText()
-    val currentVersion = parseVersion(content, file.path)
-    val currentBuild = parseBuildNumber(content, file.path)
-    val isBeta = beta.get()
-    val branch = currentBranch()
-
-    terminal.println("Current version: $currentVersion (BUILD_NUMBER = $currentBuild)")
-
-    val recentTags = recentReleaseTags()
-    if (recentTags.isNotEmpty()) {
-      terminal.println("Recent releases: ${recentTags.joinToString(", ")}")
-    }
-
-    terminal.println("")
-    runChecks(file.toRelativeString(projectDir.get().asFile), tag = null, isBeta, branch) { label, block ->
-      terminal.print("  $label...")
-      block()
-      terminal.println(" ✔")
-    }
-
-    val bumpType = promptBumpType(terminal)
-    val isBetaBump = bumpType == "beta"
-
-    if (isBetaBump) {
-      val baseBuild = Versioning.compute(currentVersion)
-      require(currentBuild >= baseBuild) {
-        "BUILD_NUMBER ($currentBuild) is less than the base for version $currentVersion ($baseBuild). " +
-          "Run 'bumpVersion -Ptype=patch' to reset, or fix version.txt manually."
-      }
-      val newBuild = currentBuild + 1
-      require(newBuild <= baseBuild + 999) {
-        "Beta number exceeded 999 for version $currentVersion. Bump patch/minor/major to continue."
-      }
-
-      terminal.println("")
-      terminal.println("  $currentVersion beta (BUILD_NUMBER = $currentBuild -> $newBuild)")
-      terminal.println("")
-
-      if (dryRun.get()) {
-        terminal.println("Dry run complete. No files modified, no commits created.")
-        return
-      }
-
-      val confirmed = YesNoPrompt(
-        prompt = "Bump build number and push?",
-        terminal = terminal,
-      ).ask() == true
-
-      if (!confirmed) {
-        terminal.println("Aborted.")
-        return
-      }
-
-      writeVersionFile(file, content, currentVersion, newBuild)
-      git("add", file.absolutePath)
-      git("commit", "-m", "chore: bump beta build number to $newBuild")
-      git("push", "origin", branch)
-
-      terminal.println("Pushed to origin/$branch.")
-      return
-    }
-
-    val newVersion = Versioning.bump(currentVersion, bumpType)
-    val newBuild = Versioning.compute(newVersion)
-    val tag = buildTag(newVersion, isBeta, branch)
-
-    val existingTag = gitOutput("tag", "--list", tag)
-    require(existingTag.isBlank()) { "Tag '$tag' already exists." }
-
-    terminal.println("")
-    terminal.println("  $currentVersion -> $newVersion (BUILD_NUMBER = $newBuild)")
-    terminal.println("")
-
-    if (dryRun.get()) {
-      val preview = previewChangelog(tag)
-      if (preview.isNotBlank()) {
-        terminal.println("Changelog preview:")
-        terminal.println(preview)
-        terminal.println("")
-      }
-      terminal.println("Dry run complete. No files modified, no commits or tags created.")
-      return
-    }
-
-    val preview = previewChangelog(tag)
-    if (preview.isNotBlank()) {
-      terminal.println("Changelog preview:")
-      terminal.println(preview)
-      terminal.println("")
-    } else {
-      terminal.println("No commits since last tag.")
-    }
-
-    val confirmed = YesNoPrompt(
-      prompt = "Commit version.txt, update CHANGELOG.md, and tag $tag?",
-      terminal = terminal,
-    ).ask() == true
-
-    if (!confirmed) {
-      terminal.println("Aborted.")
-      return
-    }
-
-    writeVersionFile(file, content, newVersion, newBuild)
-
-    val changelog = changelogFile.get().asFile
-    generateChangelog(changelog, tag)
-    terminal.println("Updated ${changelog.name}")
-
-    git("add", file.absolutePath)
-    git("add", changelog.absolutePath)
-    git("commit", "-m", "release: $tag")
-    git("tag", "-a", tag, "-m", "Release $tag")
-
-    terminal.println("Created commit and tag: $tag")
-
-    val pushConfirmed = YesNoPrompt(
-      prompt = "Push commit and tag to origin?",
-      terminal = terminal,
-    ).ask() == true
-
-    if (pushConfirmed) {
-      git("push", "origin", branch, "--tags")
-      terminal.println("Pushed to origin/$branch with tags.")
-    } else {
-      terminal.println("Skipped push. Run manually: git push origin $branch --tags")
-    }
-  }
-
-  private fun printDryRun(currentVersion: String, newVersion: String, tag: String) {
-    logger.lifecycle("$currentVersion → $newVersion")
-    logger.lifecycle("Tag: $tag")
-
-    val preview = previewChangelog(tag)
-    if (preview.isNotBlank()) {
-      logger.lifecycle("Changelog preview:")
-      logger.lifecycle(preview)
-    }
-
-    logger.lifecycle("Dry run complete. No files modified, no commits or tags created.")
-  }
-
-  private fun parseVersion(content: String, path: String): String {
-    val match = Versioning.VERSION_REGEX.find(content)
-      ?: error("VERSION_NUMBER not found in $path")
-    return match.groupValues[1]
-  }
-
-  private fun parseBuildNumber(content: String, path: String): Int {
-    val match = Versioning.BUILD_REGEX.find(content)
-      ?: error("BUILD_NUMBER not found in $path")
-    return match.groupValues[1].toIntOrNull()
-      ?: error("BUILD_NUMBER is not a valid integer in $path")
-  }
-
-  private fun writeVersionFile(file: File, content: String, newVersion: String, newBuild: Int) {
-    require(Versioning.BUILD_REGEX.containsMatchIn(content)) {
-      "BUILD_NUMBER not found in ${file.path}"
-    }
-    val updated = content
-      .replace(Versioning.VERSION_REGEX, "VERSION_NUMBER = $newVersion")
-      .replace(Versioning.BUILD_REGEX, "BUILD_NUMBER = $newBuild")
-    file.writeText(updated)
-  }
-
-  private fun runChecks(
-    versionFilePath: String,
-    tag: String?,
-    isBeta: Boolean,
-    branch: String,
-    reporter: (label: String, block: () -> Unit) -> Unit,
-  ) {
-    if (isBeta) {
-      reporter("On branch '$branch'") {}
-    } else {
-      reporter("On main branch") {
-        require(branch == "main") { "Must be on 'main' branch to release, currently on '$branch'." }
-      }
-    }
-
-    reporter("Clean working tree") {
-      val dirty = gitOutput("status", "--porcelain")
-        .lines()
-        .filter { it.isNotBlank() }
-        .filter { line -> parsePorcelainPaths(line).none { it == versionFilePath } }
-      require(dirty.isEmpty()) {
-        "Working tree has uncommitted changes:\n${dirty.joinToString("\n")}\nCommit or stash them before releasing."
-      }
-    }
-
-    reporter("Fetching remote") {
-      git("fetch", "--tags")
-      val fetchResult = execOperations.exec {
-        it.commandLine("git", "fetch", "origin", branch)
-        it.isIgnoreExitValue = true
-      }
-      if (fetchResult.exitValue != 0) {
-        logger.lifecycle("Remote branch 'origin/$branch' not found — pushing branch to origin.")
-        git("push", "-u", "origin", branch)
-      }
-    }
-
-    reporter("Branch up-to-date") {
-      val behind = gitOutput("rev-list", "--count", "HEAD..origin/$branch")
-      require(behind == "0") { "Local branch is $behind commit(s) behind origin/$branch. Pull before releasing." }
-    }
-
-    if (tag != null) {
-      val existing = gitOutput("tag", "--list", tag)
-      require(existing.isBlank()) { "Tag '$tag' already exists. Choose a different version or delete the existing tag." }
-    }
-  }
-
-  private fun recentReleaseTags(): List<String> =
-    gitOutput("tag", "--list", "v*", "--sort=-version:refname")
-      .lines()
-      .filter { it.isNotBlank() }
-      .take(5)
-
-  private fun promptBumpType(terminal: Terminal): String {
-    val validTypes = listOf("major", "minor", "patch", "beta")
-    return terminal.prompt(
-      prompt = "Bump type (major/minor/patch/beta)",
-      default = "minor",
-      convert = { input: String ->
-        val normalized = input.trim().lowercase()
-        if (normalized in validTypes) {
-          ConversionResult.Valid(normalized)
+        if (interactive.get()) {
+            runInteractive()
         } else {
-          ConversionResult.Invalid("Must be one of: ${validTypes.joinToString()}")
+            val validTypes = setOf("major", "minor", "patch", "beta")
+            require(bumpType.get() in validTypes) {
+                "Invalid bump type '${bumpType.get()}'. Must be one of: ${validTypes.joinToString()}"
+            }
+            runSilent()
         }
-      },
-    ) ?: "minor"
-  }
-
-  private fun requireGitCliff() {
-    val output = ByteArrayOutputStream()
-    val errOutput = ByteArrayOutputStream()
-    try {
-      val result = execOperations.exec {
-        it.commandLine("git-cliff", "--version")
-        it.standardOutput = output
-        it.errorOutput = errOutput
-        it.isIgnoreExitValue = true
-      }
-      require(result.exitValue == 0) {
-        "git-cliff is required but returned exit code ${result.exitValue}. " +
-          "Install it: brew install git-cliff\n" +
-          "See: https://git-cliff.org/docs/installation"
-      }
-    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-      if (e is IllegalArgumentException) throw e
-      throw IllegalStateException(
-        "git-cliff is required but not found on PATH. " +
-          "Install it: brew install git-cliff\n" +
-          "See: https://git-cliff.org/docs/installation",
-        e,
-      )
     }
-  }
 
-  private fun cliffConfigArgs(): List<String> {
-    val configFile = cliffConfigFile.orNull?.asFile
-    return if (configFile != null && configFile.exists()) {
-      listOf("--config", configFile.absolutePath)
-    } else {
-      emptyList()
+    private fun runSilent() {
+        val file = versionFile.get().asFile
+        require(file.exists()) { "version.txt not found at ${file.path}" }
+
+        val content = file.readText()
+        val currentVersion = parseVersion(content, file.path)
+        val currentBuild = parseBuildNumber(content, file.path)
+        val type = bumpType.get()
+        val isBetaBump = type == "beta"
+        val branch = currentBranch()
+
+        if (isBetaBump) {
+            val baseBuild = Versioning.compute(currentVersion)
+            require(currentBuild >= baseBuild) {
+                "BUILD_NUMBER ($currentBuild) is less than the base for version $currentVersion ($baseBuild). " +
+                    "Run 'bumpVersion -Ptype=patch' to reset, or fix version.txt manually."
+            }
+            val newBuild = currentBuild + 1
+            require(newBuild <= baseBuild + 999) {
+                "Beta number exceeded 999 for version $currentVersion. Bump patch/minor/major to continue."
+            }
+
+            if (dryRun.get()) {
+                logger.lifecycle("$currentVersion beta (BUILD_NUMBER = $currentBuild -> $newBuild)")
+                logger.lifecycle("Dry run complete. No files modified, no commits created.")
+                return
+            }
+
+            writeVersionFile(file, content, currentVersion, newBuild)
+            git("add", file.absolutePath)
+            git("commit", "-m", "chore: bump beta build number to $newBuild")
+            git("push", "origin", branch)
+
+            logger.lifecycle("$currentVersion beta (BUILD_NUMBER = $currentBuild -> $newBuild)")
+            logger.lifecycle("Pushed to origin/$branch.")
+            return
+        }
+
+        val isBeta = beta.get()
+        val newVersion = Versioning.bump(currentVersion, type)
+        val newBuild = Versioning.compute(newVersion)
+        val tag = buildTag(newVersion, isBeta, branch)
+
+        runChecks(file.toRelativeString(projectDir.get().asFile), tag, isBeta, branch) { label, block ->
+            block()
+        }
+
+        val recentTags = recentReleaseTags()
+        if (recentTags.isNotEmpty()) {
+            logger.lifecycle("Recent releases: ${recentTags.joinToString(", ")}")
+        }
+
+        if (dryRun.get()) {
+            printDryRun(currentVersion, newVersion, tag)
+            return
+        }
+
+        writeVersionFile(file, content, newVersion, newBuild)
+
+        val changelog = changelogFile.get().asFile
+        generateChangelog(changelog, tag)
+
+        git("add", file.absolutePath)
+        git("add", changelog.absolutePath)
+        git("commit", "-m", "release: $tag")
+        git("tag", "-a", tag, "-m", "Release $tag")
+        git("push", "origin", branch, "--tags")
+
+        logger.lifecycle("$currentVersion -> $newVersion (BUILD_NUMBER = $newBuild)")
+        logger.lifecycle("Pushed $tag to origin/$branch.")
     }
-  }
 
-  private fun previewChangelog(tag: String): String {
-    val output = ByteArrayOutputStream()
-    val errOutput = ByteArrayOutputStream()
-    val result = execOperations.exec {
-      it.commandLine(
-        buildList {
-          add("git-cliff")
-          addAll(cliffConfigArgs())
-          add("--unreleased")
-          add("--tag")
-          add(tag)
-          add("--strip")
-          add("header")
-        },
-      )
-      it.standardOutput = output
-      it.errorOutput = errOutput
-      it.isIgnoreExitValue = true
+    private fun runInteractive() {
+        val terminal = Terminal()
+        val file = versionFile.get().asFile
+        require(file.exists()) { "version.txt not found at ${file.path}" }
+
+        val content = file.readText()
+        val currentVersion = parseVersion(content, file.path)
+        val currentBuild = parseBuildNumber(content, file.path)
+        val isBeta = beta.get()
+        val branch = currentBranch()
+
+        terminal.println("Current version: $currentVersion (BUILD_NUMBER = $currentBuild)")
+
+        val recentTags = recentReleaseTags()
+        if (recentTags.isNotEmpty()) {
+            terminal.println("Recent releases: ${recentTags.joinToString(", ")}")
+        }
+
+        terminal.println("")
+        runChecks(file.toRelativeString(projectDir.get().asFile), tag = null, isBeta, branch) { label, block ->
+            terminal.print("  $label...")
+            block()
+            terminal.println(" ✔")
+        }
+
+        val bumpType = promptBumpType(terminal)
+        val isBetaBump = bumpType == "beta"
+
+        if (isBetaBump) {
+            val baseBuild = Versioning.compute(currentVersion)
+            require(currentBuild >= baseBuild) {
+                "BUILD_NUMBER ($currentBuild) is less than the base for version $currentVersion ($baseBuild). " +
+                    "Run 'bumpVersion -Ptype=patch' to reset, or fix version.txt manually."
+            }
+            val newBuild = currentBuild + 1
+            require(newBuild <= baseBuild + 999) {
+                "Beta number exceeded 999 for version $currentVersion. Bump patch/minor/major to continue."
+            }
+
+            terminal.println("")
+            terminal.println("  $currentVersion beta (BUILD_NUMBER = $currentBuild -> $newBuild)")
+            terminal.println("")
+
+            if (dryRun.get()) {
+                terminal.println("Dry run complete. No files modified, no commits created.")
+                return
+            }
+
+            val confirmed = YesNoPrompt(
+                prompt = "Bump build number and push?",
+                terminal = terminal,
+            ).ask() == true
+
+            if (!confirmed) {
+                terminal.println("Aborted.")
+                return
+            }
+
+            writeVersionFile(file, content, currentVersion, newBuild)
+            git("add", file.absolutePath)
+            git("commit", "-m", "chore: bump beta build number to $newBuild")
+            git("push", "origin", branch)
+
+            terminal.println("Pushed to origin/$branch.")
+            return
+        }
+
+        val newVersion = Versioning.bump(currentVersion, bumpType)
+        val newBuild = Versioning.compute(newVersion)
+        val tag = buildTag(newVersion, isBeta, branch)
+
+        val existingTag = gitOutput("tag", "--list", tag)
+        require(existingTag.isBlank()) { "Tag '$tag' already exists." }
+
+        terminal.println("")
+        terminal.println("  $currentVersion -> $newVersion (BUILD_NUMBER = $newBuild)")
+        terminal.println("")
+
+        if (dryRun.get()) {
+            val preview = previewChangelog(tag)
+            if (preview.isNotBlank()) {
+                terminal.println("Changelog preview:")
+                terminal.println(preview)
+                terminal.println("")
+            }
+            terminal.println("Dry run complete. No files modified, no commits or tags created.")
+            return
+        }
+
+        val preview = previewChangelog(tag)
+        if (preview.isNotBlank()) {
+            terminal.println("Changelog preview:")
+            terminal.println(preview)
+            terminal.println("")
+        } else {
+            terminal.println("No commits since last tag.")
+        }
+
+        val confirmed = YesNoPrompt(
+            prompt = "Commit version.txt, update CHANGELOG.md, and tag $tag?",
+            terminal = terminal,
+        ).ask() == true
+
+        if (!confirmed) {
+            terminal.println("Aborted.")
+            return
+        }
+
+        writeVersionFile(file, content, newVersion, newBuild)
+
+        val changelog = changelogFile.get().asFile
+        generateChangelog(changelog, tag)
+        terminal.println("Updated ${changelog.name}")
+
+        git("add", file.absolutePath)
+        git("add", changelog.absolutePath)
+        git("commit", "-m", "release: $tag")
+        git("tag", "-a", tag, "-m", "Release $tag")
+
+        terminal.println("Created commit and tag: $tag")
+
+        val pushConfirmed = YesNoPrompt(
+            prompt = "Push commit and tag to origin?",
+            terminal = terminal,
+        ).ask() == true
+
+        if (pushConfirmed) {
+            git("push", "origin", branch, "--tags")
+            terminal.println("Pushed to origin/$branch with tags.")
+        } else {
+            terminal.println("Skipped push. Run manually: git push origin $branch --tags")
+        }
     }
-    if (result.exitValue != 0) {
-      val stderr = errOutput.toString().trim()
-      logger.warn("git-cliff preview failed (exit ${result.exitValue}): $stderr")
-      return ""
+
+    private fun printDryRun(currentVersion: String, newVersion: String, tag: String) {
+        logger.lifecycle("$currentVersion → $newVersion")
+        logger.lifecycle("Tag: $tag")
+
+        val preview = previewChangelog(tag)
+        if (preview.isNotBlank()) {
+            logger.lifecycle("Changelog preview:")
+            logger.lifecycle(preview)
+        }
+
+        logger.lifecycle("Dry run complete. No files modified, no commits or tags created.")
     }
-    return output.toString().trim()
-  }
 
-  private fun generateChangelog(file: File, tag: String) {
-    val errOutput = ByteArrayOutputStream()
-    val result = execOperations.exec {
-      it.commandLine(
-        buildList {
-          add("git-cliff")
-          addAll(cliffConfigArgs())
-          add("--tag")
-          add(tag)
-          add("-o")
-          add(file.absolutePath)
-        },
-      )
-      it.errorOutput = errOutput
-      it.isIgnoreExitValue = true
+    private fun parseVersion(content: String, path: String): String {
+        val match = Versioning.VERSION_REGEX.find(content)
+            ?: error("VERSION_NUMBER not found in $path")
+        return match.groupValues[1]
     }
-    require(result.exitValue == 0) {
-      "git-cliff failed (exit ${result.exitValue}): ${errOutput.toString().trim()}"
+
+    private fun parseBuildNumber(content: String, path: String): Int {
+        val match = Versioning.BUILD_REGEX.find(content)
+            ?: error("BUILD_NUMBER not found in $path")
+        return match.groupValues[1].toIntOrNull()
+            ?: error("BUILD_NUMBER is not a valid integer in $path")
     }
-  }
 
-  private fun currentBranch(): String =
-    gitOutput("rev-parse", "--abbrev-ref", "HEAD")
-
-  private fun gitOutput(vararg args: String): String {
-    val output = ByteArrayOutputStream()
-    execOperations.exec {
-      it.commandLine("git", *args)
-      it.standardOutput = output
+    private fun writeVersionFile(file: File, content: String, newVersion: String, newBuild: Int) {
+        require(Versioning.BUILD_REGEX.containsMatchIn(content)) {
+            "BUILD_NUMBER not found in ${file.path}"
+        }
+        val updated = content
+            .replace(Versioning.VERSION_REGEX, "VERSION_NUMBER = $newVersion")
+            .replace(Versioning.BUILD_REGEX, "BUILD_NUMBER = $newBuild")
+        file.writeText(updated)
     }
-    return output.toString().trim()
-  }
 
-  private fun git(vararg args: String) {
-    execOperations.exec {
-      it.commandLine("git", *args)
+    private fun runChecks(
+        versionFilePath: String,
+        tag: String?,
+        isBeta: Boolean,
+        branch: String,
+        reporter: (label: String, block: () -> Unit) -> Unit,
+    ) {
+        if (isBeta) {
+            reporter("On branch '$branch'") {}
+        } else {
+            reporter("On main branch") {
+                require(branch == "main") { "Must be on 'main' branch to release, currently on '$branch'." }
+            }
+        }
+
+        reporter("Clean working tree") {
+            val dirty = gitOutput("status", "--porcelain")
+                .lines()
+                .filter { it.isNotBlank() }
+                .filter { line -> parsePorcelainPaths(line).none { it == versionFilePath } }
+            require(dirty.isEmpty()) {
+                "Working tree has uncommitted changes:\n${dirty.joinToString("\n")}\nCommit or stash them before releasing."
+            }
+        }
+
+        reporter("Fetching remote") {
+            git("fetch", "--tags")
+            val fetchResult = execOperations.exec {
+                it.commandLine("git", "fetch", "origin", branch)
+                it.isIgnoreExitValue = true
+            }
+            if (fetchResult.exitValue != 0) {
+                logger.lifecycle("Remote branch 'origin/$branch' not found — pushing branch to origin.")
+                git("push", "-u", "origin", branch)
+            }
+        }
+
+        reporter("Branch up-to-date") {
+            val behind = gitOutput("rev-list", "--count", "HEAD..origin/$branch")
+            require(behind == "0") { "Local branch is $behind commit(s) behind origin/$branch. Pull before releasing." }
+        }
+
+        if (tag != null) {
+            val existing = gitOutput("tag", "--list", tag)
+            require(existing.isBlank()) { "Tag '$tag' already exists. Choose a different version or delete the existing tag." }
+        }
     }
-  }
 
-  internal companion object {
-    internal fun buildTag(versionName: String, isBeta: Boolean, branch: String): String =
-      if (isBeta) "v$versionName-beta.${sanitizeBranchForTag(branch)}" else "v$versionName"
+    private fun recentReleaseTags(): List<String> =
+        gitOutput("tag", "--list", "v*", "--sort=-version:refname")
+            .lines()
+            .filter { it.isNotBlank() }
+            .take(5)
 
-    internal fun sanitizeBranchForTag(branch: String): String =
-      branch.replace(Regex("[^a-zA-Z0-9._-]"), "-")
-        .replace(Regex("-{2,}"), "-")
-        .trim('-')
-
-    internal fun parsePorcelainPaths(line: String): List<String> {
-      if (line.length < 3) return emptyList()
-      val path = line.substring(3) // skip "XY "
-      return if (" -> " in path) path.split(" -> ") else listOf(path)
+    private fun promptBumpType(terminal: Terminal): String {
+        val validTypes = listOf("major", "minor", "patch", "beta")
+        return terminal.prompt(
+            prompt = "Bump type (major/minor/patch/beta)",
+            default = "minor",
+            convert = { input: String ->
+                val normalized = input.trim().lowercase()
+                if (normalized in validTypes) {
+                    ConversionResult.Valid(normalized)
+                } else {
+                    ConversionResult.Invalid("Must be one of: ${validTypes.joinToString()}")
+                }
+            },
+        ) ?: "minor"
     }
-  }
+
+    private fun requireGitCliff() {
+        val output = ByteArrayOutputStream()
+        val errOutput = ByteArrayOutputStream()
+        try {
+            val result = execOperations.exec {
+                it.commandLine("git-cliff", "--version")
+                it.standardOutput = output
+                it.errorOutput = errOutput
+                it.isIgnoreExitValue = true
+            }
+            require(result.exitValue == 0) {
+                "git-cliff is required but returned exit code ${result.exitValue}. " +
+                    "Install it: brew install git-cliff\n" +
+                    "See: https://git-cliff.org/docs/installation"
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            if (e is IllegalArgumentException) throw e
+            throw IllegalStateException(
+                "git-cliff is required but not found on PATH. " +
+                    "Install it: brew install git-cliff\n" +
+                    "See: https://git-cliff.org/docs/installation",
+                e,
+            )
+        }
+    }
+
+    private fun cliffConfigArgs(): List<String> {
+        val configFile = cliffConfigFile.orNull?.asFile
+        return if (configFile != null && configFile.exists()) {
+            listOf("--config", configFile.absolutePath)
+        } else {
+            emptyList()
+        }
+    }
+
+    private fun previewChangelog(tag: String): String {
+        val output = ByteArrayOutputStream()
+        val errOutput = ByteArrayOutputStream()
+        val result = execOperations.exec {
+            it.commandLine(
+                buildList {
+                    add("git-cliff")
+                    addAll(cliffConfigArgs())
+                    add("--unreleased")
+                    add("--tag")
+                    add(tag)
+                    add("--strip")
+                    add("header")
+                },
+            )
+            it.standardOutput = output
+            it.errorOutput = errOutput
+            it.isIgnoreExitValue = true
+        }
+        if (result.exitValue != 0) {
+            val stderr = errOutput.toString().trim()
+            logger.warn("git-cliff preview failed (exit ${result.exitValue}): $stderr")
+            return ""
+        }
+        return output.toString().trim()
+    }
+
+    private fun generateChangelog(file: File, tag: String) {
+        val errOutput = ByteArrayOutputStream()
+        val result = execOperations.exec {
+            it.commandLine(
+                buildList {
+                    add("git-cliff")
+                    addAll(cliffConfigArgs())
+                    add("--tag")
+                    add(tag)
+                    add("-o")
+                    add(file.absolutePath)
+                },
+            )
+            it.errorOutput = errOutput
+            it.isIgnoreExitValue = true
+        }
+        require(result.exitValue == 0) {
+            "git-cliff failed (exit ${result.exitValue}): ${errOutput.toString().trim()}"
+        }
+    }
+
+    private fun currentBranch(): String =
+        gitOutput("rev-parse", "--abbrev-ref", "HEAD")
+
+    private fun gitOutput(vararg args: String): String {
+        val output = ByteArrayOutputStream()
+        execOperations.exec {
+            it.commandLine("git", *args)
+            it.standardOutput = output
+        }
+        return output.toString().trim()
+    }
+
+    private fun git(vararg args: String) {
+        execOperations.exec {
+            it.commandLine("git", *args)
+        }
+    }
+
+    internal companion object {
+        internal fun buildTag(versionName: String, isBeta: Boolean, branch: String): String =
+            if (isBeta) "v$versionName-beta.${sanitizeBranchForTag(branch)}" else "v$versionName"
+
+        internal fun sanitizeBranchForTag(branch: String): String =
+            branch.replace(Regex("[^a-zA-Z0-9._-]"), "-")
+                .replace(Regex("-{2,}"), "-")
+                .trim('-')
+
+        internal fun parsePorcelainPaths(line: String): List<String> {
+            if (line.length < 3) return emptyList()
+            val path = line.substring(3) // skip "XY "
+            return if (" -> " in path) path.split(" -> ") else listOf(path)
+        }
+    }
 }

--- a/plugins/src/test/kotlin/io/github/thomaskioko/gradle/plugins/utils/VersioningTest.kt
+++ b/plugins/src/test/kotlin/io/github/thomaskioko/gradle/plugins/utils/VersioningTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.plugins.utils
 
 import org.junit.Assert.assertEquals
@@ -6,96 +21,96 @@ import org.junit.Test
 
 class VersioningTest {
 
-  @Test
-  fun `should return 100000 given version 0_1_0`() {
-    assertEquals(100_000, Versioning.compute("0.1.0"))
-  }
+    @Test
+    fun `should return 100000 given version 0_1_0`() {
+        assertEquals(100_000, Versioning.compute("0.1.0"))
+    }
 
-  @Test
-  fun `should return 10203000 given version 1_2_3`() {
-    assertEquals(10_203_000, Versioning.compute("1.2.3"))
-  }
+    @Test
+    fun `should return 10203000 given version 1_2_3`() {
+        assertEquals(10_203_000, Versioning.compute("1.2.3"))
+    }
 
-  @Test
-  fun `should return 1000 given version 0_0_1`() {
-    assertEquals(1_000, Versioning.compute("0.0.1"))
-  }
+    @Test
+    fun `should return 1000 given version 0_0_1`() {
+        assertEquals(1_000, Versioning.compute("0.0.1"))
+    }
 
-  @Test
-  fun `should stay under 2_1B given max version 209_99_99`() {
-    assertEquals(2_099_999_000, Versioning.compute("209.99.99"))
-  }
+    @Test
+    fun `should stay under 2_1B given max version 209_99_99`() {
+        assertEquals(2_099_999_000, Versioning.compute("209.99.99"))
+    }
 
-  @Test(expected = IllegalArgumentException::class)
-  fun `should throw when version format is invalid`() {
-    Versioning.compute("1.2")
-  }
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw when version format is invalid`() {
+        Versioning.compute("1.2")
+    }
 
-  @Test(expected = IllegalArgumentException::class)
-  fun `should throw when major version is above 209`() {
-    Versioning.compute("210.0.0")
-  }
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw when major version is above 209`() {
+        Versioning.compute("210.0.0")
+    }
 
-  @Test(expected = IllegalArgumentException::class)
-  fun `should throw when minor version is above 99`() {
-    Versioning.compute("1.100.0")
-  }
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw when minor version is above 99`() {
+        Versioning.compute("1.100.0")
+    }
 
-  @Test(expected = IllegalArgumentException::class)
-  fun `should throw when patch version is above 99`() {
-    Versioning.compute("1.0.100")
-  }
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw when patch version is above 99`() {
+        Versioning.compute("1.0.100")
+    }
 
-  @Test(expected = IllegalArgumentException::class)
-  fun `should throw when version contains non-numeric component`() {
-    Versioning.compute("1.2.abc")
-  }
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw when version contains non-numeric component`() {
+        Versioning.compute("1.2.abc")
+    }
 
-  @Test(expected = IllegalArgumentException::class)
-  fun `should throw when version contains negative number`() {
-    Versioning.compute("-1.0.0")
-  }
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw when version contains negative number`() {
+        Versioning.compute("-1.0.0")
+    }
 
-  @Test
-  fun `should increment patch when bump type is patch`() {
-    assertEquals("0.1.1", Versioning.bump("0.1.0", "patch"))
-  }
+    @Test
+    fun `should increment patch when bump type is patch`() {
+        assertEquals("0.1.1", Versioning.bump("0.1.0", "patch"))
+    }
 
-  @Test
-  fun `should increment minor and reset patch when bump type is minor`() {
-    assertEquals("0.2.0", Versioning.bump("0.1.0", "minor"))
-  }
+    @Test
+    fun `should increment minor and reset patch when bump type is minor`() {
+        assertEquals("0.2.0", Versioning.bump("0.1.0", "minor"))
+    }
 
-  @Test
-  fun `should increment major and reset minor and patch when bump type is major`() {
-    assertEquals("1.0.0", Versioning.bump("0.1.0", "major"))
-  }
+    @Test
+    fun `should increment major and reset minor and patch when bump type is major`() {
+        assertEquals("1.0.0", Versioning.bump("0.1.0", "major"))
+    }
 
-  @Test
-  fun `should increment patch given non-zero version values`() {
-    assertEquals("1.2.4", Versioning.bump("1.2.3", "patch"))
-  }
+    @Test
+    fun `should increment patch given non-zero version values`() {
+        assertEquals("1.2.4", Versioning.bump("1.2.3", "patch"))
+    }
 
-  @Test(expected = IllegalArgumentException::class)
-  fun `should throw when bump type is invalid`() {
-    Versioning.bump("0.1.0", "hotfix")
-  }
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw when bump type is invalid`() {
+        Versioning.bump("0.1.0", "hotfix")
+    }
 
-  @Test
-  fun `should handle patch bump at high patch value`() {
-    assertEquals("0.99.99", Versioning.bump("0.99.98", "patch"))
-  }
+    @Test
+    fun `should handle patch bump at high patch value`() {
+        assertEquals("0.99.99", Versioning.bump("0.99.98", "patch"))
+    }
 
-  @Test(expected = IllegalArgumentException::class)
-  fun `should throw when patch bump exceeds limit`() {
-    Versioning.bump("0.99.99", "patch")
-  }
+    @Test(expected = IllegalArgumentException::class)
+    fun `should throw when patch bump exceeds limit`() {
+        Versioning.bump("0.99.99", "patch")
+    }
 
-  @Test
-  fun `should produce higher build number after patch bump`() {
-    val before = Versioning.compute("0.1.2")
-    val newVersion = Versioning.bump("0.1.2", "patch")
-    val after = Versioning.compute(newVersion)
-    assertTrue("Expected $after > $before", after > before)
-  }
+    @Test
+    fun `should produce higher build number after patch bump`() {
+        val before = Versioning.compute("0.1.2")
+        val newVersion = Versioning.bump("0.1.2", "patch")
+        val after = Versioning.compute(newVersion)
+        assertTrue("Expected $after > $before", after > before)
+    }
 }

--- a/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTaskTest.kt
+++ b/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTaskTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.tasks
 
 import com.squareup.kotlinpoet.ClassName

--- a/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/release/ReleaseHelperTest.kt
+++ b/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/release/ReleaseHelperTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.thomaskioko.gradle.tasks.release
 
 import org.junit.Assert.assertEquals
@@ -5,68 +20,68 @@ import org.junit.Test
 
 class ReleaseHelperTest {
 
-  @Test
-  fun `buildTag production release`() {
-    assertEquals("v0.2.0", ReleaseTask.buildTag("0.2.0", false, "main"))
-  }
+    @Test
+    fun `buildTag production release`() {
+        assertEquals("v0.2.0", ReleaseTask.buildTag("0.2.0", false, "main"))
+    }
 
-  @Test
-  fun `buildTag beta with feature branch`() {
-    assertEquals("v0.2.0-beta.feature-auth", ReleaseTask.buildTag("0.2.0", true, "feature/auth"))
-  }
+    @Test
+    fun `buildTag beta with feature branch`() {
+        assertEquals("v0.2.0-beta.feature-auth", ReleaseTask.buildTag("0.2.0", true, "feature/auth"))
+    }
 
-  @Test
-  fun `buildTag beta with simple branch`() {
-    assertEquals("v1.0.0-beta.develop", ReleaseTask.buildTag("1.0.0", true, "develop"))
-  }
+    @Test
+    fun `buildTag beta with simple branch`() {
+        assertEquals("v1.0.0-beta.develop", ReleaseTask.buildTag("1.0.0", true, "develop"))
+    }
 
-  @Test
-  fun `sanitizeBranchForTag replaces special characters`() {
-    assertEquals("fix-bug-1-test", ReleaseTask.sanitizeBranchForTag("fix/bug~1:test"))
-  }
+    @Test
+    fun `sanitizeBranchForTag replaces special characters`() {
+        assertEquals("fix-bug-1-test", ReleaseTask.sanitizeBranchForTag("fix/bug~1:test"))
+    }
 
-  @Test
-  fun `sanitizeBranchForTag collapses consecutive dashes`() {
-    assertEquals("a-b", ReleaseTask.sanitizeBranchForTag("a//b"))
-  }
+    @Test
+    fun `sanitizeBranchForTag collapses consecutive dashes`() {
+        assertEquals("a-b", ReleaseTask.sanitizeBranchForTag("a//b"))
+    }
 
-  @Test
-  fun `sanitizeBranchForTag trims leading and trailing dashes`() {
-    assertEquals("branch", ReleaseTask.sanitizeBranchForTag("/branch/"))
-  }
+    @Test
+    fun `sanitizeBranchForTag trims leading and trailing dashes`() {
+        assertEquals("branch", ReleaseTask.sanitizeBranchForTag("/branch/"))
+    }
 
-  @Test
-  fun `sanitizeBranchForTag preserves dots and underscores`() {
-    assertEquals("release_1.0", ReleaseTask.sanitizeBranchForTag("release_1.0"))
-  }
+    @Test
+    fun `sanitizeBranchForTag preserves dots and underscores`() {
+        assertEquals("release_1.0", ReleaseTask.sanitizeBranchForTag("release_1.0"))
+    }
 
-  @Test
-  fun `sanitizeBranchForTag handles complex branch names`() {
-    assertEquals("user-feat-add..thing", ReleaseTask.sanitizeBranchForTag("user/feat^add..thing"))
-  }
+    @Test
+    fun `sanitizeBranchForTag handles complex branch names`() {
+        assertEquals("user-feat-add..thing", ReleaseTask.sanitizeBranchForTag("user/feat^add..thing"))
+    }
 
-  @Test
-  fun `parsePorcelainPaths normal modified file`() {
-    assertEquals(listOf("src/Foo.kt"), ReleaseTask.parsePorcelainPaths("M  src/Foo.kt"))
-  }
+    @Test
+    fun `parsePorcelainPaths normal modified file`() {
+        assertEquals(listOf("src/Foo.kt"), ReleaseTask.parsePorcelainPaths("M  src/Foo.kt"))
+    }
 
-  @Test
-  fun `parsePorcelainPaths added file`() {
-    assertEquals(listOf("new-file.txt"), ReleaseTask.parsePorcelainPaths("A  new-file.txt"))
-  }
+    @Test
+    fun `parsePorcelainPaths added file`() {
+        assertEquals(listOf("new-file.txt"), ReleaseTask.parsePorcelainPaths("A  new-file.txt"))
+    }
 
-  @Test
-  fun `parsePorcelainPaths rename`() {
-    assertEquals(listOf("old.kt", "new.kt"), ReleaseTask.parsePorcelainPaths("R  old.kt -> new.kt"))
-  }
+    @Test
+    fun `parsePorcelainPaths rename`() {
+        assertEquals(listOf("old.kt", "new.kt"), ReleaseTask.parsePorcelainPaths("R  old.kt -> new.kt"))
+    }
 
-  @Test
-  fun `parsePorcelainPaths short line returns empty`() {
-    assertEquals(emptyList<String>(), ReleaseTask.parsePorcelainPaths("M "))
-  }
+    @Test
+    fun `parsePorcelainPaths short line returns empty`() {
+        assertEquals(emptyList<String>(), ReleaseTask.parsePorcelainPaths("M "))
+    }
 
-  @Test
-  fun `parsePorcelainPaths untracked file`() {
-    assertEquals(listOf("untracked.txt"), ReleaseTask.parsePorcelainPaths("?? untracked.txt"))
-  }
+    @Test
+    fun `parsePorcelainPaths untracked file`() {
+        assertEquals(listOf("untracked.txt"), ReleaseTask.parsePorcelainPaths("?? untracked.txt"))
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 pluginManagement {
     includeBuild("build-logic")
 }

--- a/spotless/spotless.kt
+++ b/spotless/spotless.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright $YEAR Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */


### PR DESCRIPTION
## Description
This PR adds the Apache 2.0 license text that the published artifacts have always claimed, and turns on the formatter in the places where it was doing nothing. The `plugins` and `lint-rules` builds applied Spotless without declaring a single format rule, and the shared formatting check reached codegen's build scripts but none of the modules underneath them, so most of the repository was never formatted or checked.

## Changes
- Add `LICENSE` at the repository root, matching the license every published POM declares
- Add Spotless format rules to `plugins` and `lint-rules` so their Kotlin sources are formatted and checked
- Register `spotlessApplyAll` and `spotlessCheckAll` inside the codegen build so its five modules are covered by the shared check
- Add the Apache license header to every Kotlin source file, from a shared template in `spotless/spotless.kt`
- Replace two KDoc comments that ktlint rejects, in `RootPlugin` and `DisableTasksCore`
- Apply the formatter across the repository
