### PR TITLE
Run every test suite and remove dead settings

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -1,4 +1,4 @@
-name: Gradle Setup"
+name: Gradle Setup
 
 runs:
   using: "composite"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,13 @@ on:
   pull_request:
   workflow_call:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   static-analysis:
     name: Static Analysis
@@ -84,7 +91,13 @@ jobs:
         uses: android-actions/setup-android@v4
 
       - name: Run tests
-        run: ./gradlew :plugins:functionalTest --stacktrace
+        run: |
+          ./gradlew \
+            :plugins:test \
+            :plugins:functionalTest \
+            :lint-rules:test \
+            :codegen:processor-test:test \
+            --stacktrace
 
       - name: Upload test reports
         if: failure()
@@ -92,5 +105,5 @@ jobs:
         with:
           name: test-reports
           path: |
-            plugins/build/reports/tests/functionalTest/
-            plugins/build/test-results/functionalTest/
+            **/build/reports/tests/
+            **/build/test-results/

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -2,7 +2,3 @@
 # live in gradle/publishing.properties.
 POM_NAME=App Gradle Plugins Codegen
 POM_DESCRIPTION=Annotation and KSP processor library for building Kotlin Multiplatform navigation destinations
-
-# Workaround: KGP FUS metrics crash on Gradle 9 + configuration cache with KMP iOS targets.
-# https://youtrack.jetbrains.com/issue/KT-85628. Fixed in KGP 2.3.21 / 2.4.0-Beta2.
-kotlin.internal.collectFUSMetrics=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ ktlint = "1.8.0"
 
 agp = "9.3.1"
 baselineprofile = "1.4.1"
-codegen = "0.8.4"
 dependency-analysis = "3.17.0"
 dependency-guard = "0.5.0"
 firebase-crashlytics-gradle = "3.0.7"
@@ -26,10 +25,6 @@ mordant-core = { module = "com.github.ajalt.mordant:mordant-core", version.ref =
 baselineprofile-gradlePlugin = { group = "androidx.benchmark", name = "benchmark-baseline-profile-gradle-plugin", version.ref = "baselineprofile" }
 spotless-gradle-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
-
-# Codegen artifacts (published from codegen/ composite build)
-codegen-annotations = { module = "io.github.thomaskioko.gradle.plugins:codegen-annotations", version.ref = "codegen" }
-codegen-processor = { module = "io.github.thomaskioko.gradle.plugins:codegen-processor", version.ref = "codegen" }
 
 # Build logic dependencies
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }


### PR DESCRIPTION
## Description
This PR makes the tests job actually run every test suite, and clears out three pieces of settings that no longer do anything. The job named Tests ran only the functional tests, so the unit tests in `plugins`, `lint-rules` and `codegen` ran as a side effect of the build job and a failure in them was reported against the wrong job.

## Changes
- Run `:plugins:test`, `:plugins:functionalTest`, `:lint-rules:test` and `:codegen:processor-test:test` in the tests job, and collect the reports from all of them
- Declare read-only permissions on the build workflow, and add a concurrency group so a new push to an open pull request cancels the run it replaces
- Remove the stray quote from the name of the Gradle setup action
- Remove the `codegen` version and its two aliases from the version catalog, which described this repository's own published artifacts and were never referenced here
- Remove the Kotlin metrics property from the codegen build, which worked around a crash that the comment beside it records as fixed several Kotlin releases ago
