### PR TITLE
Hide the generated graph types from Objective-C

### DIFF
--- a/codegen/docs/architecture/generators.md
+++ b/codegen/docs/architecture/generators.md
@@ -26,18 +26,38 @@ The router is a single `when` expression over the sealed `NavData`:
 
 ```kotlin
 internal object FileGenerator {
-    fun generate(data: NavData): List<FileSpec> = when (data) {
+    fun generate(data: NavData, hideFromObjC: Boolean): List<FileSpec> = when (data) {
         is ScreenData -> listOf(
-            ScreenGraphGenerator.generate(data),
-            NavDestinationBindingGenerator.generate(data),
+            ScreenGraphGenerator.generate(data, hideFromObjC),
+            NavDestinationBindingGenerator.generate(data, hideFromObjC),
         )
         is TabData -> listOf(
-            ScreenGraphGenerator.generate(data),
-            TabDestinationBindingGenerator.generate(data),
+            ScreenGraphGenerator.generate(data, hideFromObjC),
+            TabDestinationBindingGenerator.generate(data, hideFromObjC),
         )
     }
 }
 ```
+
+## Hiding from Objective-C
+
+Every graph and destination binding generator takes a `hideFromObjC` flag. When it is true, the
+emitted types (outer interface, nested `Factory`, companion object, `@AppRoot` binding object)
+carry `@HiddenFromObjC` and the file carries `@file:OptIn(ExperimentalObjCRefinement::class)`.
+The generated types are dependency injection plumbing no Swift code names, and exported
+Objective-C classes cannot be dead-stripped, so hiding them keeps the whole layer out of the
+framework header of any module a consumer exports.
+
+The flag is computed once in `NavigationCodegenProcessorProvider`: true when
+`environment.platforms` contains a non-JVM platform. `HiddenFromObjC` is an
+`@OptionalExpectation` the compiler only accepts in common module sources, so a JVM-only
+compilation (a plain JVM consumer, or the compile testing harness in `processor-test`) emits no
+refinement annotations and produces the same output as before the flag existed. The golden files
+cover the JVM path; `HideFromObjCTest` in the processor module asserts both paths on the
+rendered `FileSpec` text. The examples in this document show the JVM shape.
+
+The UI binding generators never take the flag. Their output lands in Android-only modules that no
+framework exports.
 
 Both branches reuse `ScreenGraphGenerator` because the `@GraphExtension` interface looks the same for screens, overlays, and tab roots. The route class doubles as the
 scope marker either way. The two branches diverge only in which destination binding generator runs alongside.

--- a/codegen/processor/build.gradle.kts
+++ b/codegen/processor/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
     api(libs.ksp.api)
     implementation(libs.kotlinpoet)
     implementation(libs.kotlinpoet.ksp)
+
+    testImplementation(libs.junit)
 }
 
 mavenPublishing {

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessor.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessor.kt
@@ -58,10 +58,15 @@ import io.github.thomaskioko.codegen.processor.parser.parseUiBindingData
  *   incremental compilation.
  * @property logger KSP's diagnostic sink. The processor uses it to report validation errors that
  *   KSP turns into compile errors at the offending symbol.
+ * @property hideFromObjC Whether generated graph and binding types carry `@HiddenFromObjC`. True
+ *   when the compilation has a non-JVM target. The generated dependency injection plumbing is
+ *   never named from Swift, and exported Objective-C classes cannot be dead-stripped, so hiding
+ *   the types keeps them out of the framework header of any module a consumer exports.
  */
 public class NavigationCodegenProcessor(
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger,
+    private val hideFromObjC: Boolean,
 ) : SymbolProcessor {
     /**
      * Runs one KSP round. Iterates the seven annotations the processor knows about, hands each
@@ -96,7 +101,7 @@ public class NavigationCodegenProcessor(
                 continue
             }
             val data = parseChildPresenterData(declaration, logger) ?: continue
-            writeFiles(declaration, listOf(ChildGraphGenerator.generate(data)))
+            writeFiles(declaration, listOf(ChildGraphGenerator.generate(data, hideFromObjC)))
         }
     }
 
@@ -115,7 +120,7 @@ public class NavigationCodegenProcessor(
                 continue
             }
             val data = parseAppRootData(declaration, logger) ?: continue
-            writeFiles(declaration, listOf(AppRootBindingGenerator.generate(data)))
+            writeFiles(declaration, listOf(AppRootBindingGenerator.generate(data, hideFromObjC)))
         }
     }
 
@@ -203,7 +208,7 @@ public class NavigationCodegenProcessor(
                 continue
             }
             val data = parse(declaration) ?: continue
-            writeFiles(declaration, FileGenerator.generate(data))
+            writeFiles(declaration, FileGenerator.generate(data, hideFromObjC))
         }
     }
 

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessorProvider.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/NavigationCodegenProcessorProvider.kt
@@ -15,6 +15,7 @@
  */
 package io.github.thomaskioko.codegen.processor
 
+import com.google.devtools.ksp.processing.JvmPlatformInfo
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -32,13 +33,20 @@ public class NavigationCodegenProcessorProvider : SymbolProcessorProvider {
     /**
      * Creates the [NavigationCodegenProcessor] KSP will run for the current build.
      *
-     * @param environment KSP's per build environment. Provides the file writer and diagnostic
-     *   logger the processor needs.
+     * Generated types carry `@HiddenFromObjC` unless every target platform is JVM. The annotation
+     * is an optional expectation the compiler only accepts in common module sources, so a
+     * JVM-only compilation (a plain JVM consumer, or the compile testing harness) must not emit
+     * it, while a multiplatform compilation with a native target wants the generated dependency
+     * injection types kept out of the Objective-C framework header.
+     *
+     * @param environment KSP's per build environment. Provides the file writer, the diagnostic
+     *   logger, and the target platforms the processor needs.
      * @return A new processor instance bound to the supplied environment.
      */
     override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
         NavigationCodegenProcessor(
             codeGenerator = environment.codeGenerator,
             logger = environment.logger,
+            hideFromObjC = environment.platforms.any { it !is JvmPlatformInfo },
         )
 }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/AppRootBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/AppRootBindingGenerator.kt
@@ -27,6 +27,8 @@ import io.github.thomaskioko.codegen.processor.util.FOUR_SPACE_INDENT
 import io.github.thomaskioko.codegen.processor.util.Provides
 import io.github.thomaskioko.codegen.processor.util.bindingContainer
 import io.github.thomaskioko.codegen.processor.util.contributesTo
+import io.github.thomaskioko.codegen.processor.util.hideFromObjC
+import io.github.thomaskioko.codegen.processor.util.optInObjCRefinement
 import io.github.thomaskioko.codegen.processor.util.singleIn
 
 /**
@@ -47,9 +49,11 @@ internal object AppRootBindingGenerator {
      *
      * @param data The parsed annotation, which carries the implementation, the bound interface,
      *   the factory class and function names, and the parent scope.
+     * @param hideFromObjC Whether to hide the generated binding from the Objective-C API. True
+     *   when the compilation has a non-JVM target.
      * @return The generated binding file as a KotlinPoet [FileSpec].
      */
-    fun generate(data: AppRootData): FileSpec {
+    fun generate(data: AppRootData, hideFromObjC: Boolean): FileSpec {
         val factoryParam = ParameterSpec.builder("factory", data.factoryClassName).build()
         val componentContextParam = ParameterSpec.builder("componentContext", ComponentContext).build()
 
@@ -65,6 +69,7 @@ internal object AppRootBindingGenerator {
 
         val bindingObject = TypeSpec.objectBuilder(data.bindingClassName)
             .addModifiers(KModifier.PUBLIC)
+            .hideFromObjC(hideFromObjC)
             .addAnnotation(bindingContainer())
             .addAnnotation(contributesTo(data.parentScope))
             .addFunction(provideFun)
@@ -72,6 +77,7 @@ internal object AppRootBindingGenerator {
 
         return FileSpec.builder(data.bindingClassName)
             .indent(FOUR_SPACE_INDENT)
+            .optInObjCRefinement(hideFromObjC)
             .addType(bindingObject)
             .build()
     }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/BindingFiles.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/BindingFiles.kt
@@ -22,6 +22,8 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
 import io.github.thomaskioko.codegen.processor.util.FOUR_SPACE_INDENT
 import io.github.thomaskioko.codegen.processor.util.contributesTo
+import io.github.thomaskioko.codegen.processor.util.hideFromObjC
+import io.github.thomaskioko.codegen.processor.util.optInObjCRefinement
 
 /**
  * Builds a binding file structured as
@@ -37,27 +39,33 @@ import io.github.thomaskioko.codegen.processor.util.contributesTo
  *
  * @param bindingName The class name of the generated binding interface.
  * @param parentScope The parent dependency injection scope the binding contributes to.
+ * @param hideFromObjC Whether to hide the generated types from the Objective-C API. True when
+ *   the compilation has a non-JVM target.
  * @param providers The `@Provides @IntoSet` functions to declare inside the companion object.
  * @return A KotlinPoet [FileSpec] containing the binding interface and its companion.
  */
 internal fun contributingBindingFile(
     bindingName: ClassName,
     parentScope: ClassName,
+    hideFromObjC: Boolean,
     vararg providers: FunSpec,
 ): FileSpec {
     val companion = TypeSpec.companionObjectBuilder()
         .addModifiers(KModifier.PUBLIC)
+        .hideFromObjC(hideFromObjC)
         .also { builder -> providers.forEach { builder.addFunction(it) } }
         .build()
 
     val bindingInterface = TypeSpec.interfaceBuilder(bindingName)
         .addModifiers(KModifier.PUBLIC)
+        .hideFromObjC(hideFromObjC)
         .addAnnotation(contributesTo(parentScope))
         .addType(companion)
         .build()
 
     return FileSpec.builder(bindingName)
         .indent(FOUR_SPACE_INDENT)
+        .optInObjCRefinement(hideFromObjC)
         .addType(bindingInterface)
         .build()
 }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/ChildGraphGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/ChildGraphGenerator.kt
@@ -28,6 +28,8 @@ import io.github.thomaskioko.codegen.processor.util.Provides
 import io.github.thomaskioko.codegen.processor.util.contributesTo
 import io.github.thomaskioko.codegen.processor.util.graphExtension
 import io.github.thomaskioko.codegen.processor.util.graphExtensionFactory
+import io.github.thomaskioko.codegen.processor.util.hideFromObjC
+import io.github.thomaskioko.codegen.processor.util.optInObjCRefinement
 
 /**
  * Generates the graph extension file for a `@ChildPresenter` annotated class.
@@ -44,9 +46,11 @@ internal object ChildGraphGenerator {
      *
      * @param data The parsed annotation, which carries the presenter class, the graph scope, and
      *   the parent scope.
+     * @param hideFromObjC Whether to hide the generated types from the Objective-C API. True when
+     *   the compilation has a non-JVM target.
      * @return The generated graph file as a KotlinPoet [FileSpec].
      */
-    fun generate(data: ChildPresenterData): FileSpec {
+    fun generate(data: ChildPresenterData, hideFromObjC: Boolean): FileSpec {
         val factoryFun = FunSpec.builder(data.graphFactoryFunName)
             .addModifiers(KModifier.PUBLIC, KModifier.ABSTRACT)
             .addParameter(
@@ -59,6 +63,7 @@ internal object ChildGraphGenerator {
 
         val factoryInterface = TypeSpec.interfaceBuilder(data.graphClassName.nestedClass("Factory"))
             .addModifiers(KModifier.PUBLIC)
+            .hideFromObjC(hideFromObjC)
             .addAnnotation(contributesTo(data.parentScope))
             .addAnnotation(graphExtensionFactory())
             .addFunction(factoryFun)
@@ -70,6 +75,7 @@ internal object ChildGraphGenerator {
 
         val graphInterface = TypeSpec.interfaceBuilder(data.graphClassName)
             .addModifiers(KModifier.PUBLIC)
+            .hideFromObjC(hideFromObjC)
             .addAnnotation(graphExtension(data.scope))
             .addProperty(presenterProperty)
             .addType(factoryInterface)
@@ -77,6 +83,7 @@ internal object ChildGraphGenerator {
 
         return FileSpec.builder(data.graphClassName)
             .indent(FOUR_SPACE_INDENT)
+            .optInObjCRefinement(hideFromObjC)
             .addType(graphInterface)
             .build()
     }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/FileGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/FileGenerator.kt
@@ -38,17 +38,19 @@ internal object FileGenerator {
      *
      * @param data The parsed annotation. [ScreenData] for screens and overlays, [TabData] for tab
      *   roots.
+     * @param hideFromObjC Whether to hide the generated types from the Objective-C API. True when
+     *   the compilation has a non-JVM target.
      * @return A pair of [FileSpec] outputs: the graph file and the binding file.
      */
-    fun generate(data: NavData): List<FileSpec> = when (data) {
+    fun generate(data: NavData, hideFromObjC: Boolean): List<FileSpec> = when (data) {
         is ScreenData -> listOf(
-            ScreenGraphGenerator.generate(data),
-            NavDestinationBindingGenerator.generate(data),
+            ScreenGraphGenerator.generate(data, hideFromObjC),
+            NavDestinationBindingGenerator.generate(data, hideFromObjC),
         )
 
         is TabData -> listOf(
-            ScreenGraphGenerator.generate(data),
-            TabDestinationBindingGenerator.generate(data),
+            ScreenGraphGenerator.generate(data, hideFromObjC),
+            TabDestinationBindingGenerator.generate(data, hideFromObjC),
         )
     }
 }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/NavDestinationBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/NavDestinationBindingGenerator.kt
@@ -95,11 +95,14 @@ internal object NavDestinationBindingGenerator {
      *
      * @param data The parsed annotation, which carries every name, scope, and parameterization
      *   detail the generator needs.
+     * @param hideFromObjC Whether to hide the generated binding from the Objective-C API. True
+     *   when the compilation has a non-JVM target.
      * @return The generated binding file as a KotlinPoet [FileSpec].
      */
-    fun generate(data: ScreenData): FileSpec = contributingBindingFile(
+    fun generate(data: ScreenData, hideFromObjC: Boolean): FileSpec = contributingBindingFile(
         bindingName = data.bindingClassName,
         parentScope = data.parentScope,
+        hideFromObjC = hideFromObjC,
         destinationFun(data),
         routeBindingFun(data.baseName, data.route),
     )

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/ScreenGraphGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/ScreenGraphGenerator.kt
@@ -28,6 +28,8 @@ import io.github.thomaskioko.codegen.processor.util.Provides
 import io.github.thomaskioko.codegen.processor.util.contributesTo
 import io.github.thomaskioko.codegen.processor.util.graphExtension
 import io.github.thomaskioko.codegen.processor.util.graphExtensionFactory
+import io.github.thomaskioko.codegen.processor.util.hideFromObjC
+import io.github.thomaskioko.codegen.processor.util.optInObjCRefinement
 
 /**
  * Generates the Metro `@GraphExtension` interface plus its nested `Factory` for one annotated
@@ -64,11 +66,14 @@ internal object ScreenGraphGenerator {
      * Generates the graph file for one parsed presenter annotation.
      *
      * @param data The parsed annotation, which carries every name and scope the generator needs.
+     * @param hideFromObjC Whether to hide the generated types from the Objective-C API. True when
+     *   the compilation has a non-JVM target.
      * @return The generated graph file as a KotlinPoet [FileSpec].
      */
-    fun generate(data: NavData): FileSpec {
+    fun generate(data: NavData, hideFromObjC: Boolean): FileSpec {
         val factoryInterface = TypeSpec.interfaceBuilder("Factory")
             .addModifiers(KModifier.PUBLIC)
+            .hideFromObjC(hideFromObjC)
             .addAnnotation(contributesTo(data.parentScope))
             .addAnnotation(graphExtensionFactory())
             .addFunction(
@@ -86,6 +91,7 @@ internal object ScreenGraphGenerator {
 
         val graphInterface = TypeSpec.interfaceBuilder(data.graphClassName)
             .addModifiers(KModifier.PUBLIC)
+            .hideFromObjC(hideFromObjC)
             .addAnnotation(graphExtension(data.scope))
             .addProperty(
                 PropertySpec.builder(data.graphPropertyName, data.graphPropertyType)
@@ -97,6 +103,7 @@ internal object ScreenGraphGenerator {
 
         return FileSpec.builder(data.graphClassName)
             .indent(FOUR_SPACE_INDENT)
+            .optInObjCRefinement(hideFromObjC)
             .addType(graphInterface)
             .build()
     }

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/TabDestinationBindingGenerator.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/codegen/TabDestinationBindingGenerator.kt
@@ -77,11 +77,14 @@ internal object TabDestinationBindingGenerator {
      * Generates the binding file for one tab root presenter annotation.
      *
      * @param data The parsed annotation, which carries every name and scope the generator needs.
+     * @param hideFromObjC Whether to hide the generated binding from the Objective-C API. True
+     *   when the compilation has a non-JVM target.
      * @return The generated binding file as a KotlinPoet [FileSpec].
      */
-    fun generate(data: TabData): FileSpec = contributingBindingFile(
+    fun generate(data: TabData, hideFromObjC: Boolean): FileSpec = contributingBindingFile(
         bindingName = data.bindingClassName,
         parentScope = data.parentScope,
+        hideFromObjC = hideFromObjC,
         destinationFun(data),
         navRootFun(data),
         rootBindingFun(data),

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/External.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/External.kt
@@ -36,6 +36,15 @@ import com.squareup.kotlinpoet.ClassName
 internal const val DECOMPOSE_PACKAGE: String = "com.arkivanov.decompose"
 internal val ComponentContext: ClassName = ClassName(DECOMPOSE_PACKAGE, "ComponentContext")
 
+// Kotlin standard library: the Objective-C export refinement annotation and its opt-in marker.
+// Generated dependency injection types are plumbing no Swift code names, so every graph and
+// binding file hides its types from the Objective-C API of any framework that exports the module.
+// HiddenFromObjC is an optional expectation the compiler only accepts in common module sources,
+// so the processor emits it only when the compilation has a non-JVM target.
+internal val OptIn: ClassName = ClassName("kotlin", "OptIn")
+internal val HiddenFromObjC: ClassName = ClassName("kotlin.native", "HiddenFromObjC")
+internal val ExperimentalObjCRefinement: ClassName = ClassName("kotlin.experimental", "ExperimentalObjCRefinement")
+
 // Metro: the dependency injection framework the codegen targets. Every generated annotation
 // references one of these. BindingContainer is used only by UiBindingGenerator; see the rationale
 // on that generator for why.

--- a/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/KotlinPoet.kt
+++ b/codegen/processor/src/main/kotlin/io/github/thomaskioko/codegen/processor/util/KotlinPoet.kt
@@ -17,9 +17,11 @@ package io.github.thomaskioko.codegen.processor.util
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.TypeSpec
 
 /** Indent string used by every emitted [com.squareup.kotlinpoet.FileSpec]. KSP convention is four spaces. */
 internal const val FOUR_SPACE_INDENT: String = "    "
@@ -73,6 +75,30 @@ internal fun graphExtension(scope: ClassName): AnnotationSpec =
  */
 internal fun graphExtensionFactory(): AnnotationSpec =
     AnnotationSpec.builder(GraphExtension.nestedClass("Factory")).build()
+
+/**
+ * Adds the `@HiddenFromObjC` annotation when [hide] is true. Exported Objective-C classes cannot
+ * be dead-stripped, and no Swift code names the generated dependency injection types, so hiding
+ * them keeps the plumbing out of any framework header. The flag is false for JVM-only
+ * compilations, where the annotation's `@OptionalExpectation` declaration does not resolve.
+ */
+internal fun TypeSpec.Builder.hideFromObjC(hide: Boolean): TypeSpec.Builder =
+    if (hide) addAnnotation(AnnotationSpec.builder(HiddenFromObjC).build()) else this
+
+/**
+ * Adds the `@file:OptIn(ExperimentalObjCRefinement::class)` annotation when [hide] is true, which
+ * [hideFromObjC] requires on Kotlin 2.4.
+ */
+internal fun FileSpec.Builder.optInObjCRefinement(hide: Boolean): FileSpec.Builder =
+    if (hide) {
+        addAnnotation(
+            AnnotationSpec.builder(OptIn)
+                .addMember("%T::class", ExperimentalObjCRefinement)
+                .build(),
+        )
+    } else {
+        this
+    }
 
 /**
  * Returns this class name parameterized by `*`, for example `NavDestination<*>`. Used when the

--- a/codegen/processor/src/test/kotlin/io/github/thomaskioko/codegen/processor/codegen/HideFromObjCTest.kt
+++ b/codegen/processor/src/test/kotlin/io/github/thomaskioko/codegen/processor/codegen/HideFromObjCTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.thomaskioko.codegen.processor.codegen
+
+import com.squareup.kotlinpoet.ClassName
+import io.github.thomaskioko.codegen.processor.data.AppRootData
+import io.github.thomaskioko.codegen.processor.data.ChildPresenterData
+import io.github.thomaskioko.codegen.processor.data.ScreenData
+import io.github.thomaskioko.codegen.processor.data.TabData
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the `hideFromObjC` flag on every generator. The compile testing suite in
+ * `processor-test` runs JVM-only compilations, where the flag is always false, so the true path
+ * is asserted here on the rendered [com.squareup.kotlinpoet.FileSpec] text instead.
+ */
+class HideFromObjCTest {
+
+    @Test
+    fun `should hide the child graph and its factory given a non jvm target`() {
+        val file = ChildGraphGenerator.generate(childPresenterData(), hideFromObjC = true).toString()
+
+        assertEquals(2, file.occurrencesOf("@HiddenFromObjC"))
+        assertTrue(file.contains("@file:OptIn(ExperimentalObjCRefinement::class)"))
+    }
+
+    @Test
+    fun `should hide the screen graph and its factory given a non jvm target`() {
+        val file = ScreenGraphGenerator.generate(screenData(), hideFromObjC = true).toString()
+
+        assertEquals(2, file.occurrencesOf("@HiddenFromObjC"))
+        assertTrue(file.contains("@file:OptIn(ExperimentalObjCRefinement::class)"))
+    }
+
+    @Test
+    fun `should hide the destination binding and its companion given a non jvm target`() {
+        val screenBinding = NavDestinationBindingGenerator.generate(screenData(), hideFromObjC = true).toString()
+        val tabBinding = TabDestinationBindingGenerator.generate(tabData(), hideFromObjC = true).toString()
+
+        assertEquals(2, screenBinding.occurrencesOf("@HiddenFromObjC"))
+        assertEquals(2, tabBinding.occurrencesOf("@HiddenFromObjC"))
+        assertTrue(screenBinding.contains("@file:OptIn(ExperimentalObjCRefinement::class)"))
+        assertTrue(tabBinding.contains("@file:OptIn(ExperimentalObjCRefinement::class)"))
+    }
+
+    @Test
+    fun `should hide the app root binding container given a non jvm target`() {
+        val file = AppRootBindingGenerator.generate(appRootData(), hideFromObjC = true).toString()
+
+        assertEquals(1, file.occurrencesOf("@HiddenFromObjC"))
+        assertTrue(file.contains("@file:OptIn(ExperimentalObjCRefinement::class)"))
+    }
+
+    @Test
+    fun `should emit no refinement annotations given a jvm only target`() {
+        val files = listOf(
+            ChildGraphGenerator.generate(childPresenterData(), hideFromObjC = false),
+            ScreenGraphGenerator.generate(screenData(), hideFromObjC = false),
+            NavDestinationBindingGenerator.generate(screenData(), hideFromObjC = false),
+            TabDestinationBindingGenerator.generate(tabData(), hideFromObjC = false),
+            AppRootBindingGenerator.generate(appRootData(), hideFromObjC = false),
+        )
+
+        files.map { it.toString() }.forEach { file ->
+            assertFalse(file.contains("HiddenFromObjC"))
+            assertFalse(file.contains("ExperimentalObjCRefinement"))
+        }
+    }
+
+    private fun childPresenterData() = ChildPresenterData(
+        presenterClass = ClassName("com.example.shows", "ShowsPresenter"),
+        baseName = "Shows",
+        packageName = "com.example.shows.di",
+        scope = ClassName("com.example.shows", "ShowsScope"),
+        parentScope = ClassName("com.example", "ActivityScope"),
+    )
+
+    private fun screenData() = ScreenData(
+        presenterClass = ClassName("com.example.shows", "ShowsPresenter"),
+        baseName = "Shows",
+        packageName = "com.example.shows.di",
+        parentScope = ClassName("com.example", "ActivityScope"),
+        scope = ClassName("com.example.shows", "ShowsRoute"),
+        route = ClassName("com.example.shows", "ShowsRoute"),
+    )
+
+    private fun tabData() = TabData(
+        presenterClass = ClassName("com.example.shows", "ShowsPresenter"),
+        baseName = "Shows",
+        packageName = "com.example.shows.di",
+        parentScope = ClassName("com.example", "ActivityScope"),
+        scope = ClassName("com.example.shows", "ShowsRoute"),
+        configEnclosing = ClassName("com.example.shows", "ShowsRoute"),
+    )
+
+    private fun appRootData() = AppRootData(
+        implClassName = ClassName("com.example.root", "DefaultRootPresenter"),
+        interfaceClassName = ClassName("com.example.root", "RootPresenter"),
+        factoryClassName = ClassName("com.example.root", "DefaultRootPresenter", "Factory"),
+        factoryFunctionName = "create",
+        parentScope = ClassName("com.example", "ActivityScope"),
+        packageName = "com.example.root.di",
+    )
+
+    private fun String.occurrencesOf(needle: String): Int = split(needle).size - 1
+}

--- a/gradle/publishing.properties
+++ b/gradle/publishing.properties
@@ -2,7 +2,7 @@
 # Composite-specific overrides (POM_NAME, POM_DESCRIPTION) stay in each
 # composite's own gradle.properties.
 GROUP=io.github.thomaskioko.gradle.plugins
-VERSION_NAME=0.8.5
+VERSION_NAME=0.8.6
 INCEPTION_YEAR=2025
 
 POM_REPO_NAME=app-gradle-plugins


### PR DESCRIPTION
## Description
This PR hides the generated dependency injection types from the Objective-C API of any framework that exports a consumer module. Swift never names them, and exported Objective-C classes cannot be dead-stripped, so they were pure header and binary weight.

