### PR TITLE
Update API visibility and make internal calls internal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ local.properties
 gradle.properties.local
 
 /.kotlin
-tasks
+/tasks
 
 # Claude skills — untracked while iterating; remove once stable
 .claude/skills/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ Change Log
 
 ## 0.8.6
 
-- Add the Apache 2.0 license text at the repository root. Every published POM declared `The Apache Software License, Version 2.0` but the license itself was never committed, so GitHub reported the project as unlicensed.
-- Add the Apache license header to every Kotlin source file, so the published sources carry it too. `plugins` and `lint-rules` applied the Spotless plugin without declaring a format block, and the aggregate check reached codegen's build scripts but none of its modules, so most of the repository was never formatted or checked.
+- Add the Apache 2.0 license text at the repository root. Every artifact says it is licensed under Apache 2.0, but the license itself was never committed, so GitHub read the project as having no license.
+- Add the Apache license header to every Kotlin file, so the published sources carry it too. The formatter was switched on for `plugins` and `lint-rules` but never told which files to read, so most of the project had never been formatted or checked.
+- Update the API visibility and make internal calls internal: `ScaffoldProperties`, `Versioning`, the classes behind the `bumpVersion`, `release`, `generateMokoStrings` and `generateBuildConfig` tasks, and the companion objects on the ktlint rules. You configure the plugins through `scaffold {}`, so nothing a build script is meant to use has changed. If yours did call one of these, please open an issue.
 
 ## 0.8.5 *(2026-07-24)*
 

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/NoManualNavBindingRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/NoManualNavBindingRule.kt
@@ -102,7 +102,7 @@ public class NoManualNavBindingRule :
         return userType.referencedName
     }
 
-    public companion object {
+    internal companion object {
         internal const val PROVIDES_ANNOTATION: String = "Provides"
         internal const val INTO_SET_ANNOTATION: String = "IntoSet"
 

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/PresenterCodegenAnnotationRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/codegen/PresenterCodegenAnnotationRule.kt
@@ -104,7 +104,7 @@ public class PresenterCodegenAnnotationRule :
         emit(node.startOffset, errorMessage(name), false)
     }
 
-    public companion object {
+    internal companion object {
         internal val INJECTION_ANNOTATIONS: Set<String> = setOf(
             "Inject",
             "AssistedInject",

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/metro/MetroRedundantInjectRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/metro/MetroRedundantInjectRule.kt
@@ -110,7 +110,7 @@ public class MetroRedundantInjectRule :
     private fun ASTNode.isWhiteSpaceWithNewline(): Boolean =
         elementType == WHITE_SPACE && textContains('\n')
 
-    public companion object {
+    internal companion object {
         internal const val INJECT_ANNOTATION: String = "Inject"
 
         internal val CONTRIBUTES_ANNOTATIONS: Set<String> = setOf(
@@ -120,7 +120,7 @@ public class MetroRedundantInjectRule :
             "ContributesTo",
         )
 
-        public const val ERROR_MESSAGE: String =
+        internal const val ERROR_MESSAGE: String =
             "@Inject is redundant when a @Contributes... annotation is present. " +
                 "Metro applies @Inject implicitly. Remove the @Inject annotation."
     }

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoCustomNavigatorInterfaceRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoCustomNavigatorInterfaceRule.kt
@@ -73,7 +73,7 @@ public class NoCustomNavigatorInterfaceRule :
         emit(node.startOffset, errorMessage(name), false)
     }
 
-    public companion object {
+    internal companion object {
         internal const val NAVIGATOR_SUFFIX: String = "Navigator"
         internal val CANONICAL_NAVIGATORS: Set<String> = setOf(
             "Navigator",
@@ -85,7 +85,7 @@ public class NoCustomNavigatorInterfaceRule :
          *
          * @param name The simple name of the offending interface.
          */
-        public fun errorMessage(name: String): String =
+        internal fun errorMessage(name: String): String =
             "Custom Navigator interface '$name' is forbidden. " +
                 "Use canonical Navigator or SheetNavigator from navigation/api. " +
                 "New navigators require an architecture review."

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoMutatingRouterImportRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoMutatingRouterImportRule.kt
@@ -96,7 +96,7 @@ public class NoMutatingRouterImportRule :
         emit(node.startOffset, errorMessage(fqn), false)
     }
 
-    public companion object {
+    internal companion object {
         internal val FORBIDDEN_PREFIXES: Set<String> = setOf(
             "com.arkivanov.decompose.router.stack",
             "com.arkivanov.decompose.router.slot",
@@ -112,7 +112,7 @@ public class NoMutatingRouterImportRule :
          *
          * @param fqn The fully qualified name of the offending import (or the wildcard form).
          */
-        public fun errorMessage(fqn: String): String =
+        internal fun errorMessage(fqn: String): String =
             "Import '$fqn' is forbidden outside navigation modules. " +
                 "Use Navigator or SheetNavigator from navigation/api for navigation operations. " +
                 "Only ChildStack and ChildSlot may be imported elsewhere (read-only types for render sites)."

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoNavigationConstructOutsideNavRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/navigation/NoNavigationConstructOutsideNavRule.kt
@@ -84,7 +84,7 @@ public class NoNavigationConstructOutsideNavRule :
         emit(node.startOffset, errorMessage(name), false)
     }
 
-    public companion object {
+    internal companion object {
         internal const val STACK_NAVIGATION: String = "StackNavigation"
         internal const val SLOT_NAVIGATION: String = "SlotNavigation"
 
@@ -94,7 +94,7 @@ public class NoNavigationConstructOutsideNavRule :
          * @param name Either `"StackNavigation"` or `"SlotNavigation"`, whichever was
          *   constructed.
          */
-        public fun errorMessage(name: String): String =
+        internal fun errorMessage(name: String): String =
             "$name<T>() may only be constructed inside a navigation/* module. " +
                 "Inject Navigator from navigation/api instead."
     }

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/preview/NoStyleWrapperInPreviewRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/preview/NoStyleWrapperInPreviewRule.kt
@@ -130,7 +130,7 @@ public class NoStyleWrapperInPreviewRule :
             entry.shortName?.asString()?.contains(PREVIEW_MARKER) == true
         }
 
-    public companion object {
+    internal companion object {
         internal const val PREVIEW_MARKER: String = "Preview"
 
         /**
@@ -141,7 +141,7 @@ public class NoStyleWrapperInPreviewRule :
          * @param functionName The name of the enclosing preview function the wrapper was found
          *   in.
          */
-        public fun errorMessage(wrapper: String, functionName: String): String =
+        internal fun errorMessage(wrapper: String, functionName: String): String =
             "Preview '$functionName' wraps its body in '$wrapper { ... }', but the styling is " +
                 "applied automatically by TvManiacPreviewWrapperProvider. " +
                 "Remove the wrapper and add @PreviewWrapper(TvManiacPreviewWrapperProvider::class) to the preview."

--- a/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/tests/TestNameFormatRule.kt
+++ b/lint-rules/src/main/kotlin/io/github/thomaskioko/gradle/plugins/lint/tests/TestNameFormatRule.kt
@@ -87,7 +87,7 @@ public class TestNameFormatRule :
             (contains("Given") || contains("When"))
     }
 
-    public companion object {
+    internal companion object {
         internal val TEST_ANNOTATIONS: Set<String> = setOf(
             "Test",
             "ParameterizedTest",
@@ -99,7 +99,7 @@ public class TestNameFormatRule :
          *
          * @param name The function name that violated the convention.
          */
-        public fun errorMessage(name: String): String =
+        internal fun errorMessage(name: String): String =
             "Test name '$name' does not follow the project convention. " +
                 "Use 'should X given Y' (backticked) or 'shouldXGivenY' / 'shouldXWhenY' (camelCase). " +
                 "The name must start with 'should' and contain 'given' or 'when'."

--- a/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/AppPluginFunctionalTest.kt
+++ b/plugins/src/functionalTest/kotlin/io/github/thomaskioko/gradle/plugins/functional/AppPluginFunctionalTest.kt
@@ -17,6 +17,7 @@ package io.github.thomaskioko.gradle.plugins.functional
 
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -41,6 +42,18 @@ class AppPluginFunctionalTest {
         val result = project.runner(":app:help", "--task", ":app:release").build()
 
         assertEquals(TaskOutcome.SUCCESS, result.task(":app:help")?.outcome)
+    }
+
+    @Test
+    fun `running bumpVersion rewrites the version file`() {
+        val project = Fixtures.extract("app-only", tempFolder.newFolder("project"))
+
+        val result = project.runner(":app:bumpVersion").build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":app:bumpVersion")?.outcome)
+        val versionFile = project.rootDir.resolve("version.txt").readText()
+        assertTrue(versionFile, versionFile.contains("VERSION_NUMBER = 1.1.0"))
+        assertTrue(versionFile, versionFile.contains("BUILD_NUMBER = 10100000"))
     }
 
     @Test

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/properties/ScaffoldProperties.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/properties/ScaffoldProperties.kt
@@ -20,53 +20,53 @@ import io.github.thomaskioko.gradle.plugins.utils.stringProperty
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 
-public class ScaffoldProperties internal constructor(project: Project) {
-    public val composeMetrics: Provider<Boolean> =
+internal class ScaffoldProperties(project: Project) {
+    internal val composeMetrics: Provider<Boolean> =
         project.booleanProperty(PropertyKeys.COMPOSE_METRICS, false)
 
-    public val composeReports: Provider<Boolean> =
+    internal val composeReports: Provider<Boolean> =
         project.booleanProperty(PropertyKeys.COMPOSE_REPORTS, false)
 
-    public val composeCompilerReports: Provider<String> =
+    internal val composeCompilerReports: Provider<String> =
         project.stringProperty(PropertyKeys.COMPOSE_COMPILER_REPORTS)
 
-    public val debugOnly: Provider<Boolean> =
+    internal val debugOnly: Provider<Boolean> =
         project.booleanProperty(PropertyKeys.APP_DEBUG_ONLY, false)
 
-    public val enableIos: Provider<Boolean> =
+    internal val enableIos: Provider<Boolean> =
         project.booleanProperty(PropertyKeys.APP_ENABLE_IOS, false)
 
-    public val javaToolchainsStrict: Provider<Boolean> =
+    internal val javaToolchainsStrict: Provider<Boolean> =
         project.booleanProperty(PropertyKeys.JAVA_TOOLCHAINS_STRICT, false)
 
-    public val appVersionSuffix: Provider<String> =
+    internal val appVersionSuffix: Provider<String> =
         project.stringProperty(PropertyKeys.APP_VERSION_SUFFIX).orElse("-beta")
 
-    public val packageName: Provider<String> =
+    internal val packageName: Provider<String> =
         project.stringProperty(PropertyKeys.PACKAGE_NAME)
 
-    public val releaseType: Provider<String> =
+    internal val releaseType: Provider<String> =
         project.stringProperty(PropertyKeys.RELEASE_TYPE).orElse("minor")
 
-    public val releaseBeta: Provider<Boolean> =
+    internal val releaseBeta: Provider<Boolean> =
         project.stringProperty(PropertyKeys.RELEASE_BETA).map { true }.orElse(false)
 
-    public val releaseInteractive: Provider<Boolean> =
+    internal val releaseInteractive: Provider<Boolean> =
         project.stringProperty(PropertyKeys.RELEASE_INTERACTIVE).map { true }.orElse(false)
 
-    public val releaseDryRun: Provider<Boolean> =
+    internal val releaseDryRun: Provider<Boolean> =
         project.stringProperty(PropertyKeys.RELEASE_DRY_RUN).map { true }.orElse(false)
 
-    public val releaseStoreFile: Provider<String> =
+    internal val releaseStoreFile: Provider<String> =
         project.stringProperty(PropertyKeys.RELEASE_STORE_FILE)
 
-    public val releaseStorePassword: Provider<String> =
+    internal val releaseStorePassword: Provider<String> =
         project.stringProperty(PropertyKeys.RELEASE_STORE_PASSWORD)
 
-    public val releaseKeyAlias: Provider<String> =
+    internal val releaseKeyAlias: Provider<String> =
         project.stringProperty(PropertyKeys.RELEASE_KEY_ALIAS)
 
-    public val releaseKeyPassword: Provider<String> =
+    internal val releaseKeyPassword: Provider<String> =
         project.stringProperty(PropertyKeys.RELEASE_KEY_PASSWORD)
 }
 

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/Versioning.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/utils/Versioning.kt
@@ -15,12 +15,12 @@
  */
 package io.github.thomaskioko.gradle.plugins.utils
 
-public object Versioning {
+internal object Versioning {
 
-    public val VERSION_REGEX: Regex = Regex("""VERSION_NUMBER\s*=\s*(\S+)""")
-    public val BUILD_REGEX: Regex = Regex("""BUILD_NUMBER\s*=\s*(\S+)""")
+    internal val VERSION_REGEX: Regex = Regex("""VERSION_NUMBER\s*=\s*(\S+)""")
+    internal val BUILD_REGEX: Regex = Regex("""BUILD_NUMBER\s*=\s*(\S+)""")
 
-    public fun compute(versionName: String): Int {
+    internal fun compute(versionName: String): Int {
         val (major, minor, patch) = parseSemver(versionName)
         require(major in 0..209) { "Major version must be 0-209, got: $major" }
         require(minor in 0..99) { "Minor version must be 0-99, got: $minor" }
@@ -30,7 +30,7 @@ public object Versioning {
         return result
     }
 
-    public fun bump(versionName: String, bumpType: String): String {
+    internal fun bump(versionName: String, bumpType: String): String {
         val (major, minor, patch) = parseSemver(versionName)
         val (newMajor, newMinor, newPatch) = when (bumpType) {
             "major" -> Triple(major + 1, 0, 0)

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/BuildConfigGeneratorTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/BuildConfigGeneratorTask.kt
@@ -39,7 +39,7 @@ import javax.inject.Inject
  *
  */
 @CacheableTask
-public abstract class BuildConfigGeneratorTask
+internal abstract class BuildConfigGeneratorTask
 @Inject constructor(
     objectFactory: ObjectFactory,
     layout: ProjectLayout,
@@ -54,36 +54,36 @@ public abstract class BuildConfigGeneratorTask
      * The package name for the generated BuildConfig class.
      */
     @get:Input
-    public abstract val packageName: Property<String>
+    internal abstract val packageName: Property<String>
 
     /**
      * Custom string fields to add to BuildConfig.
      */
     @get:Input
-    public abstract val stringFields: MapProperty<String, String>
+    internal abstract val stringFields: MapProperty<String, String>
 
     /**
      * Custom boolean fields to add to BuildConfig.
      */
     @get:Input
-    public abstract val booleanFields: MapProperty<String, Boolean>
+    internal abstract val booleanFields: MapProperty<String, Boolean>
 
     /**
      * Custom int fields to add to BuildConfig.
      */
     @get:Input
-    public abstract val intFields: MapProperty<String, Int>
+    internal abstract val intFields: MapProperty<String, Int>
 
     /**
      * Output directory for the generated BuildConfig.kt file.
      * Defaults to build/generated/buildconfig/commonMain/kotlin
      */
     @get:OutputDirectory
-    public val outputDirectory: DirectoryProperty = objectFactory.directoryProperty()
+    internal val outputDirectory: DirectoryProperty = objectFactory.directoryProperty()
         .convention(layout.buildDirectory.dir("generated/buildconfig/commonMain/kotlin"))
 
     @TaskAction
-    public fun generate() {
+    internal fun generate() {
         val outputDir = outputDirectory.get().asFile
         val pkg = packageName.get()
 

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTask.kt
@@ -39,7 +39,7 @@ import java.io.File
 import javax.inject.Inject
 
 @CacheableTask
-public abstract class MokoResourceGeneratorTask
+internal abstract class MokoResourceGeneratorTask
 @Inject constructor(
     objectFactory: ObjectFactory,
     layout: ProjectLayout,
@@ -51,12 +51,12 @@ public abstract class MokoResourceGeneratorTask
     }
 
     @get:Input
-    public val resourcePackage: Property<String> = objectFactory.property(String::class.java)
+    internal val resourcePackage: Property<String> = objectFactory.property(String::class.java)
         .convention("com.thomaskioko.tvmaniac.i18n")
 
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    public val mokoGeneratedFile: RegularFileProperty = objectFactory.fileProperty()
+    internal val mokoGeneratedFile: RegularFileProperty = objectFactory.fileProperty()
         .convention(
             resourcePackage.flatMap { pkg ->
                 val packagePath = pkg.replace('.', '/')
@@ -65,11 +65,11 @@ public abstract class MokoResourceGeneratorTask
         )
 
     @get:OutputDirectory
-    public val commonMainOutput: DirectoryProperty = objectFactory.directoryProperty()
+    internal val commonMainOutput: DirectoryProperty = objectFactory.directoryProperty()
         .convention(layout.buildDirectory.dir("generated/resources"))
 
     @TaskAction
-    public fun generate() {
+    internal fun generate() {
         val outputDir = commonMainOutput.get().asFile
         val mrFile = mokoGeneratedFile.get().asFile
         val packageName = resourcePackage.get()

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/BumpVersionTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/BumpVersionTask.kt
@@ -25,7 +25,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.UntrackedTask
 
 @UntrackedTask(because = "Modifies version.txt in place")
-public abstract class BumpVersionTask : DefaultTask() {
+internal abstract class BumpVersionTask : DefaultTask() {
 
     init {
         description = "Bumps VERSION_NUMBER (major/minor/patch/beta) and updates BUILD_NUMBER in version.txt"
@@ -33,13 +33,13 @@ public abstract class BumpVersionTask : DefaultTask() {
     }
 
     @get:Internal
-    public abstract val versionFile: RegularFileProperty
+    internal abstract val versionFile: RegularFileProperty
 
     @get:Input
-    public abstract val bumpType: Property<String>
+    internal abstract val bumpType: Property<String>
 
     @TaskAction
-    public fun bump() {
+    internal fun bump() {
         val file = versionFile.get().asFile
         require(file.exists()) { "version.txt not found at ${file.path}" }
 

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/ReleaseTask.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/tasks/release/ReleaseTask.kt
@@ -34,7 +34,7 @@ import java.io.File
 import javax.inject.Inject
 
 @UntrackedTask(because = "Modifies version.txt, CHANGELOG.md and creates git commit + tag")
-public abstract class ReleaseTask @Inject constructor(
+internal abstract class ReleaseTask @Inject constructor(
     private val execOperations: ExecOperations,
 ) : DefaultTask() {
 
@@ -44,31 +44,31 @@ public abstract class ReleaseTask @Inject constructor(
     }
 
     @get:Internal
-    public abstract val versionFile: RegularFileProperty
+    internal abstract val versionFile: RegularFileProperty
 
     @get:Internal
-    public abstract val changelogFile: RegularFileProperty
+    internal abstract val changelogFile: RegularFileProperty
 
     @get:Internal
-    public abstract val cliffConfigFile: RegularFileProperty
+    internal abstract val cliffConfigFile: RegularFileProperty
 
     @get:Internal
-    public abstract val projectDir: DirectoryProperty
+    internal abstract val projectDir: DirectoryProperty
 
     @get:Input
-    public abstract val bumpType: Property<String>
+    internal abstract val bumpType: Property<String>
 
     @get:Input
-    public abstract val beta: Property<Boolean>
+    internal abstract val beta: Property<Boolean>
 
     @get:Input
-    public abstract val interactive: Property<Boolean>
+    internal abstract val interactive: Property<Boolean>
 
     @get:Input
-    public abstract val dryRun: Property<Boolean>
+    internal abstract val dryRun: Property<Boolean>
 
     @TaskAction
-    public fun release() {
+    internal fun release() {
         requireGitCliff()
 
         if (interactive.get()) {

--- a/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/BuildConfigGeneratorTaskTest.kt
+++ b/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/BuildConfigGeneratorTaskTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Thomas Kioko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.thomaskioko.gradle.tasks
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BuildConfigGeneratorTaskTest {
+
+    private fun createTask(): BuildConfigGeneratorTask {
+        val project = ProjectBuilder.builder().build()
+        return project.tasks.register("generateBuildConfig", BuildConfigGeneratorTask::class.java).get()
+    }
+
+    @Test
+    fun `generate writes the declared fields into BuildConfig`() {
+        val task = createTask()
+        task.packageName.set("com.thomaskioko.tvmaniac.core.base")
+        task.stringFields.set(mapOf("TMDB_API_KEY" to "abc123"))
+        task.booleanFields.set(mapOf("IS_DEBUG" to true))
+        task.intFields.set(mapOf("TIMEOUT_SECONDS" to 30))
+
+        task.generate()
+
+        val generated = task.outputDirectory.get().asFile
+            .resolve("com/thomaskioko/tvmaniac/core/base/BuildConfig.kt")
+            .readText()
+
+        assertTrue(generated, generated.contains("package com.thomaskioko.tvmaniac.core.base"))
+        assertTrue(generated, generated.contains("""TMDB_API_KEY: String = "abc123""""))
+        assertTrue(generated, generated.contains("IS_DEBUG: Boolean = true"))
+        assertTrue(generated, generated.contains("TIMEOUT_SECONDS: Int = 30"))
+    }
+}

--- a/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTaskTest.kt
+++ b/plugins/src/test/kotlin/io/github/thomaskioko/gradle/tasks/MokoResourceGeneratorTaskTest.kt
@@ -91,4 +91,24 @@ class MokoResourceGeneratorTaskTest {
         val expected = loadResource("moko-generator/expected/PluralsResourceKey.kt")
         assertEquals(expected, fileSpec.toString())
     }
+
+    @Test
+    fun `generate writes both resource key files`() {
+        val task = createTask()
+        val outputDir = File(task.project.layout.buildDirectory.get().asFile, "resource-keys")
+        task.mokoGeneratedFile.set(loadResourceFile("moko-generator/MR.kt"))
+        task.commonMainOutput.set(outputDir)
+
+        task.generate()
+
+        val packagePath = File(outputDir, "com/thomaskioko/tvmaniac/i18n")
+        assertEquals(
+            loadResource("moko-generator/expected/StringResourceKey.kt"),
+            File(packagePath, "StringResourceKey.kt").readText(),
+        )
+        assertEquals(
+            loadResource("moko-generator/expected/PluralsResourceKey.kt"),
+            File(packagePath, "PluralsResourceKey.kt").readText(),
+        )
+    }
 }


### PR DESCRIPTION
## Description
This PR updates the API visibility across the published modules and makes internal calls internal, so the documentation the next change generates describes only what a consumer can actually use. These modules require every declaration to state whether it is public, and the answer given at the time was usually public.

## Changes
- Make `ScaffoldProperties` and `Versioning` internal, along with their members
- Make the classes behind the `bumpVersion`, `release`, `generateMokoStrings` and `generateBuildConfig` tasks internal
- Make the companion objects on the eight ktlint rules internal, along with the message builders they hold
- Run the generated tasks in the tests rather than only compiling against them, since Gradle has to keep creating these classes and generating their property implementations
- Anchor the `tasks` entry in the ignore file to the repository root, so a new file in the tasks source package is visible to git again

## Bug Fixes
- A new test file added under the tasks source package could not be committed. The ignore file matched any directory named `tasks` at any depth, so the file never appeared in `git status`.
