### PR TITLE
Build an API reference from the source comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ gradle.properties.local
 /.kotlin
 /tasks
 
+# Generated API reference
+/docs/api/
+
 # Claude skills — untracked while iterating; remove once stable
 .claude/skills/
 CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Change Log
 
 - Add the Apache 2.0 license text at the repository root. Every artifact says it is licensed under Apache 2.0, but the license itself was never committed, so GitHub read the project as having no license.
 - Add the Apache license header to every Kotlin file, so the published sources carry it too. The formatter was switched on for `plugins` and `lint-rules` but never told which files to read, so most of the project had never been formatted or checked.
+- Ship real API documentation with every artifact. The documentation file attached to each release has been empty every time, because nothing ever generated one. All six artifacts now carry the full reference built from the comments in the source.
 - Update the API visibility and make internal calls internal: `ScaffoldProperties`, `Versioning`, the classes behind the `bumpVersion`, `release`, `generateMokoStrings` and `generateBuildConfig` tasks, and the companion objects on the ktlint rules. You configure the plugins through `scaffold {}`, so nothing a build script is meant to use has changed. If yours did call one of these, please open an issue.
 
 ## 0.8.5 *(2026-07-24)*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,14 @@ tasks.register("publishLocal") {
     dependsOn(gradle.includedBuild("lint-rules").task(":publishToMavenLocal"))
 }
 
+tasks.register("dokkaAll") {
+    group = "documentation"
+    description = "Generate the API reference across plugins + lint-rules + codegen composite builds."
+    dependsOn(gradle.includedBuild("plugins").task(":dokkaGenerate"))
+    dependsOn(gradle.includedBuild("lint-rules").task(":dokkaGenerate"))
+    dependsOn(gradle.includedBuild("codegen").task(":dokkaGenerate"))
+}
+
 tasks.register("buildHealthAll") {
     group = "verification"
     description = "Run buildHealth across plugins + lint-rules + codegen composite builds."

--- a/codegen/annotations/MODULE.md
+++ b/codegen/annotations/MODULE.md
@@ -1,0 +1,36 @@
+# Module annotations
+
+Adding a screen to a navigation graph by hand means writing a graph extension for the presenter,
+registering a destination factory, registering a route binding so the screen survives save and
+restore, and repeating all of it for the next screen. The work is mechanical and it is easy to get
+one of the four wrong.
+
+These annotations replace that. Mark the presenter, and the processor in `codegen-processor`
+generates the graph and the bindings next to it, in files the IDE can navigate to.
+
+```kotlin
+@Inject
+@NavDestination(
+  route = ShowsRoute::class,
+  parentScope = ActivityScope::class,
+  kind = DestinationKind.SCREEN,
+)
+class ShowsPresenter(
+  componentContext: ComponentContext,
+) : ComponentContext by componentContext
+```
+
+Published as `io.github.thomaskioko.gradle.plugins:codegen-annotations`.
+
+# Package io.github.thomaskioko.codegen.annotations
+
+The annotation set, split by what the annotated declaration is.
+
+- `@NavDestination` marks a presenter the navigator can route to, as a screen, an overlay or a tab
+- `@ChildPresenter` marks a presenter that needs a graph but is built by its parent rather than
+  routed to
+- `@AppRoot` marks the root of the navigation tree
+- `@ScreenUi`, `@SheetUi`, `@TabUi` and `@AppRootUi` mark the composables that render them
+
+Each annotation's own documentation lists the files it generates and the errors the processor
+reports for it.

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 import com.diffplug.gradle.spotless.SpotlessExtension
+import org.jetbrains.dokka.gradle.DokkaExtension
 
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.publish) apply false
+    alias(libs.plugins.dokka)
     alias(libs.plugins.spotless)
     alias(libs.plugins.dependency.analysis)
 }
@@ -49,12 +51,53 @@ tasks.register("spotlessCheckAll") {
     dependsOn(subprojects.map { "${it.path}:spotlessCheck" })
 }
 
+dependencies {
+    dokka(project(":annotations"))
+    dokka(project(":featureflag-annotations"))
+    dokka(project(":processor"))
+    dokka(project(":featureflag-processor"))
+}
+
+dokka {
+    dokkaPublications.html {
+        outputDirectory.set(rootProject.file("../docs/api/codegen"))
+        suppressInheritedMembers.set(true)
+        failOnWarning.set(false)
+    }
+}
+
 subprojects {
     group = property("GROUP").toString()
     version = property("VERSION_NAME").toString()
 
     pluginManager.apply("com.autonomousapps.dependency-analysis")
     pluginManager.apply("com.diffplug.spotless")
+
+    val moduleDir = projectDir
+    val moduleName = name
+
+    pluginManager.withPlugin("com.vanniktech.maven.publish") {
+        pluginManager.apply("org.jetbrains.dokka")
+
+        configure<DokkaExtension> {
+            dokkaSourceSets.configureEach {
+                if (name.startsWith("ios")) {
+                    suppress.set(true)
+                }
+
+                includes.from("MODULE.md")
+                jdkVersion.set(libs.versions.java.target.get().toInt())
+                skipDeprecated.set(true)
+                reportUndocumented.set(true)
+
+                sourceLink {
+                    localDirectory.set(moduleDir)
+                    remoteUrl("${property("POM_SCM_URL")}/blob/main/codegen/$moduleName")
+                    remoteLineSuffix.set("#L")
+                }
+            }
+        }
+    }
 
     configure<SpotlessExtension> {
         kotlin {

--- a/codegen/featureflag-annotations/MODULE.md
+++ b/codegen/featureflag-annotations/MODULE.md
@@ -1,0 +1,27 @@
+# Module featureflag-annotations
+
+Every feature flag added by hand costs a qualifier annotation and two provider functions, one to
+build the flag and one to add it to the set the debug screen reads. Three declarations for a
+single boolean, and the flag is invisible in the debug screen if the second provider is forgotten.
+
+`@FeatureFlag` replaces all three. Declare the flag once and the processor in
+`codegen-featureflag-processor` generates the rest.
+
+```kotlin
+@FeatureFlag(
+  key = "enable_continue_watching_nitro",
+  title = "Progress Endpoint",
+  description = "Use Trakt's progress call instead of the multi-step fetch.",
+  defaultValue = false,
+  dateAdded = "2026-05-20",
+)
+object ContinueWatchingNitroFlag
+```
+
+Published as `io.github.thomaskioko.gradle.plugins:codegen-featureflag-annotations`.
+
+# Package io.github.thomaskioko.codegen.annotations
+
+`@FeatureFlag` and the `Platform` enumeration that limits a flag to the platforms it applies to.
+The annotation's own documentation lists the files it generates and the values the processor
+rejects.

--- a/codegen/featureflag-processor/MODULE.md
+++ b/codegen/featureflag-processor/MODULE.md
@@ -1,0 +1,20 @@
+# Module featureflag-processor
+
+The symbol processor behind `@FeatureFlag`. It reads each annotated declaration and writes the
+qualifier and the binding pair, and reports a compile error when the flag is declared with a blank
+key, a blank title or a date that is not a valid `YYYY-MM-DD`.
+
+Nothing here is called from application code. The processor runs under KSP, which the
+`useFeatureFlagCodegen()` option in `scaffold {}` sets up.
+
+```kotlin
+scaffold {
+  useFeatureFlagCodegen()
+}
+```
+
+Published as `io.github.thomaskioko.gradle.plugins:codegen-featureflag-processor`.
+
+# Package io.github.thomaskioko.codegen.featureflag.processor
+
+The processor entry point and the provider KSP loads it through.

--- a/codegen/processor/MODULE.md
+++ b/codegen/processor/MODULE.md
@@ -1,0 +1,25 @@
+# Module processor
+
+The symbol processor behind the navigation annotations. It reads each annotated presenter and
+composable and writes the graph extension, the destination binding and the route binding that the
+annotation promises.
+
+Nothing here is called from application code. The processor runs under KSP, which the
+`useCodegen()` option in `scaffold {}` sets up.
+
+```kotlin
+scaffold {
+  useCodegen()
+}
+```
+
+This documentation is here for anyone changing how the generated code looks, or working out why a
+particular file was emitted. The generated shapes themselves are described on the annotations in
+`codegen-annotations`, which is the better starting point when using them rather than changing
+them.
+
+Published as `io.github.thomaskioko.gradle.plugins:codegen-processor`.
+
+# Package io.github.thomaskioko.codegen.processor
+
+The processor entry point and the provider KSP loads it through.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ agp = "9.3.1"
 baselineprofile = "1.4.1"
 dependency-analysis = "3.17.0"
 dependency-guard = "0.5.0"
+dokka = "2.2.0"
 firebase-crashlytics-gradle = "3.0.7"
 gradle-doctor = "0.12.1"
 kctfork = "0.13.0"
@@ -60,6 +61,7 @@ slf4j-simple = { module = "org.slf4j:slf4j-simple", version = "2.0.18" }
 app-root = { id = "io.github.thomaskioko.gradle.plugins.root" }
 app-spotless = { id = "io.github.thomaskioko.gradle.plugins.spotless" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/lint-rules/MODULE.md
+++ b/lint-rules/MODULE.md
@@ -1,0 +1,47 @@
+# Module lint-rules
+
+Some conventions cannot be enforced by a type: that navigation is only constructed inside the
+modules that own it, that a presenter carries the code generation annotation instead of a binding
+written by hand, that a test is named after the behaviour it checks. These are the ktlint rules
+that catch those in review instead of leaving them to a reviewer.
+
+The rules are loaded through a ktlint rule set provider, so nothing here is called directly. Add
+the artifact to Spotless as a custom rule set, or apply the lint plugin and let it do that.
+
+```kotlin
+plugins {
+  id("io.github.thomaskioko.gradle.plugins.lint")
+}
+```
+
+The rules that need an escape hatch read their exemptions from `.editorconfig`, so a module that
+legitimately breaks one says so in the file it applies to rather than disabling the rule
+everywhere.
+
+# Package io.github.thomaskioko.gradle.plugins.lint
+
+The rule set provider ktlint discovers, and the identifier the rules are registered under.
+
+# Package io.github.thomaskioko.gradle.plugins.lint.navigation
+
+Rules that keep navigation construction and routing inside the modules meant to own them, and that
+stop a project from growing a second navigator interface alongside the canonical one.
+
+# Package io.github.thomaskioko.gradle.plugins.lint.codegen
+
+Rules that require the code generation annotations rather than the bindings a developer would
+otherwise write by hand, since the two drift apart the moment one of them changes.
+
+# Package io.github.thomaskioko.gradle.plugins.lint.metro
+
+Rules for Metro dependency injection annotations, mainly the ones that are already implied by
+another annotation on the same declaration.
+
+# Package io.github.thomaskioko.gradle.plugins.lint.preview
+
+Rules for Compose preview functions, which are easy to write in a way that renders correctly in
+the preview and nowhere else.
+
+# Package io.github.thomaskioko.gradle.plugins.lint.tests
+
+Rules for test naming.

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.dependency.analysis)
+    alias(libs.plugins.dokka)
     alias(libs.plugins.publish)
     alias(libs.plugins.spotless)
 }
@@ -43,6 +44,27 @@ spotless {
         ktlint(ktlintVersion)
         target("*.kts")
         licenseHeaderFile(licenseHeader, "(import|plugins|pluginManagement|dependencyResolutionManagement)")
+    }
+}
+
+dokka {
+    dokkaSourceSets.configureEach {
+        includes.from("MODULE.md")
+        jdkVersion.set(17)
+        skipDeprecated.set(true)
+        reportUndocumented.set(true)
+
+        sourceLink {
+            localDirectory.set(projectDir)
+            remoteUrl("${property("POM_SCM_URL")}/blob/main/lint-rules")
+            remoteLineSuffix.set("#L")
+        }
+    }
+
+    dokkaPublications.html {
+        outputDirectory.set(rootProject.file("../docs/api/lint-rules"))
+        suppressInheritedMembers.set(true)
+        failOnWarning.set(false)
     }
 }
 

--- a/plugins/MODULE.md
+++ b/plugins/MODULE.md
@@ -1,0 +1,53 @@
+# Module plugins
+
+A module in a large project spends most of its build file repeating the same setup: the same
+target platforms, the same compiler flags, the same test dependencies. These plugins move that
+setup out of the build file and leave behind a `scaffold {}` block where a module declares only
+the choices it actually has to make.
+
+Apply the root plugin on the root project, then one plugin per module.
+
+```kotlin
+// root build.gradle.kts
+plugins {
+  id("io.github.thomaskioko.gradle.plugins.root")
+}
+```
+
+```kotlin
+// a module's build.gradle.kts
+plugins {
+  id("io.github.thomaskioko.gradle.plugins.multiplatform")
+}
+
+scaffold {
+  useMetro()
+}
+```
+
+The root plugin registers the aggregate test tasks, sets the daemon toolchain vendor, configures
+dependency analysis and the module graph tasks, and checks that it was applied to the root project
+and not a module. Every module plugin checks that the root plugin is present and fails with a clear
+message when it is not.
+
+# Package io.github.thomaskioko.gradle.plugins
+
+The plugin entry points. Each one is registered under an `io.github.thomaskioko.gradle.plugins.*`
+identifier and is applied from a build file.
+
+- `root` on the root project, before anything else
+- `app`, `android`, `jvm` or `multiplatform` on a module, one of the four
+- `base` when a module needs the shared setup without a platform
+- `baseline.profile`, `resource.generator` and `buildconfig` for the modules that need them
+
+# Package io.github.thomaskioko.gradle.plugins.extensions
+
+The `scaffold {}` block and the platform blocks nested inside it. This is where a module says what
+it is: which platforms it targets, whether it uses Compose, which dependency injection and code
+generation it needs, and which dependencies to hold to a baseline.
+
+# Package io.github.thomaskioko.gradle.plugins.checks
+
+Static analysis applied to a module. `SpotlessPlugin` configures Spotless with the project's ktlint
+setup, and `LintPlugin` adds the custom rule set from the `lint-rules` artifact so those rules run
+alongside the standard ones.

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("java-gradle-plugin")
     alias(libs.plugins.dependency.analysis)
+    alias(libs.plugins.dokka)
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.publish)
     alias(libs.plugins.spotless)
@@ -42,6 +43,38 @@ spotless {
         ktlint(ktlintVersion)
         target("*.kts")
         licenseHeaderFile(licenseHeader, "(import|plugins|pluginManagement|dependencyResolutionManagement)")
+    }
+}
+
+val agpDocsVersion = libs.versions.agp.get().split(".").take(2).joinToString(".")
+
+dokka {
+    dokkaSourceSets.configureEach {
+        includes.from("MODULE.md")
+        jdkVersion.set(libs.versions.java.target.get().toInt())
+        skipDeprecated.set(true)
+        reportUndocumented.set(true)
+
+        sourceLink {
+            localDirectory.set(projectDir)
+            remoteUrl("${property("POM_SCM_URL")}/blob/main/plugins")
+            remoteLineSuffix.set("#L")
+        }
+
+        externalDocumentationLinks.register("gradle") {
+            url("https://docs.gradle.org/${gradle.gradleVersion}/javadoc/")
+            packageListUrl("https://docs.gradle.org/${gradle.gradleVersion}/javadoc/element-list")
+        }
+
+        externalDocumentationLinks.register("agp") {
+            url("https://developer.android.com/reference/tools/gradle-api/$agpDocsVersion/")
+        }
+    }
+
+    dokkaPublications.html {
+        outputDirectory.set(rootProject.file("../docs/api/plugins"))
+        suppressInheritedMembers.set(true)
+        failOnWarning.set(false)
     }
 }
 


### PR DESCRIPTION
## Description
This PR builds a browsable API reference from the comments already written in the source. The comments were always there, but nothing ever turned them into anything a reader could open, so the documentation file attached to every release so far has been empty.

## Changes
- Build the reference for the plugins, the lint rules and the codegen modules, and write each one into its own folder under `docs/api`
- Gather the four published codegen modules into a single reference rather than four separate ones, and leave out the test module and the iOS sources
- Link every entry back to the file and line it came from on GitHub, and out to the Gradle and Android reference pages for types this project does not own
- Give each module a short page of prose that opens the reference, in `MODULE.md`
- Add a `dokkaAll` task that builds all three, matching the shape of the other tasks that reach across the separate builds
- Report entries that have no comment yet, without failing the build

## Bug Fixes
- The documentation file attached to each published artifact was empty on every release. All six artifacts now carry the real reference.
