### PR TITLE
Add a documentation site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,29 @@ jobs:
             **/build/reports/
             **/build/test-results/
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    needs: static-analysis
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Gradle
+        uses: ./.github/actions/gradle-setup
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Install site dependencies
+        run: python3 -m pip install -r mkdocs-requirements.txt
+
+      - name: Build site
+        run: ./deploy_website.sh --ci
+
   tests:
     name: Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,56 @@
+name: Publish Docs
+
+on:
+  push:
+    tags:
+      - '**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy-docs:
+    name: Deploy Documentation
+    runs-on: ubuntu-latest
+    if: github.repository == 'thomaskioko/app-gradle-plugins'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Gradle
+        uses: ./.github/actions/gradle-setup
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Install site dependencies
+        run: python3 -m pip install -r mkdocs-requirements.txt
+
+      - name: Build site
+        run: ./deploy_website.sh --ci
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload site
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+      - name: Deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,11 @@ gradle.properties.local
 # Generated API reference
 /docs/api/
 
+# Documentation site build output and the pages copied in from the root
+/site/
+/docs/changelog.md
+/docs/releasing.md
+
 # Claude skills — untracked while iterating; remove once stable
 .claude/skills/
 CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Change Log
 
 - Add the Apache 2.0 license text at the repository root. Every artifact says it is licensed under Apache 2.0, but the license itself was never committed, so GitHub read the project as having no license.
 - Add the Apache license header to every Kotlin file, so the published sources carry it too. The formatter was switched on for `plugins` and `lint-rules` but never told which files to read, so most of the project had never been formatted or checked.
+- Publish a documentation site at <https://thomaskioko.github.io/app-gradle-plugins/>, carrying the API reference, the change log and the release guide. It is rebuilt and published each time a release is tagged, and every pull request rebuilds it and fails if a link or a menu entry points at a page that is not there.
 - Ship real API documentation with every artifact. The documentation file attached to each release has been empty every time, because nothing ever generated one. All six artifacts now carry the full reference built from the comments in the source.
 - Update the API visibility and make internal calls internal: `ScaffoldProperties`, `Versioning`, the classes behind the `bumpVersion`, `release`, `generateMokoStrings` and `generateBuildConfig` tasks, and the companion objects on the ktlint rules. You configure the plugins through `scaffold {}`, so nothing a build script is meant to use has changed. If yours did call one of these, please open an issue.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Three additions extend the codegen surface so consumers no longer hand-write tab
 - `@ChildPresenter` targets a presenter constructed by another presenter rather than navigated to through a route. The processor emits a `<Presenter>ChildGraph` graph extension exposing the presenter as a property plus a `@ContributesTo(parentScope) @GraphExtension.Factory` whose `create<BaseName>Graph` function takes a `ComponentContext` and returns the graph. Multiple children may share a `scope`; each gets its own graph extension and its own factory function (the unique name avoids return-type collisions when both factories contribute to the same parent scope).
 - `@NavDestination(kind = TAB_ROOT)` now also contributes the route singleton itself into `Set<NavRoot>`. Consumers no longer need to keep a hand-written `<Feature>RootBinding` next to each tab to populate that set. The new contribution lives inside the existing `<Presenter>TabDestinationBinding` file alongside the `NavDestination<*>` and `NavRootBinding<*>` entries.
 
-See [annotations.md](codegen/docs/annotations.md), [examples.md](codegen/docs/examples.md) sections 4, 7, and 8, and [architecture/consumer-contract.md](codegen/docs/architecture/consumer-contract.md) for the full surface.
+See [annotations.md](https://github.com/thomaskioko/app-gradle-plugins/blob/main/codegen/docs/annotations.md), [examples.md](https://github.com/thomaskioko/app-gradle-plugins/blob/main/codegen/docs/examples.md) sections 4, 7, and 8, and [architecture/consumer-contract.md](https://github.com/thomaskioko/app-gradle-plugins/blob/main/codegen/docs/architecture/consumer-contract.md) for the full surface.
 
 ### Lint rules
 
@@ -80,7 +80,7 @@ Two new annotations cover the application's root host. The pair eliminates the m
 - `@AppRoot` targets an `@AssistedInject` presenter implementation. The processor reads the nested `@AssistedFactory`, infers the bound interface from the implementation's supertypes, and emits a `<InterfaceName>BindingContainer` that contributes `@Provides @SingleIn(parentScope)` for the bound interface. Consumers replace their hand-written root binding container with one annotation.
 - `@AppRootUi` targets the host `@Composable` function. The processor reads the function's non-modifier parameters and emits an `AppRootProvider` interface plus a `@Composable AppRootProvider.AppRootContent(modifier)` extension. Consumers make their activity-scope `@DependencyGraph` extend the generated `AppRootProvider`, and the activity invokes `graph.AppRootContent()` instead of forwarding each dependency by hand.
 
-The codegen now publishes `@SingleIn`, `@Composable`, and `Modifier` in addition to the previously-published Metro and Decompose constants. See [annotations.md](codegen/docs/annotations.md), [examples.md](codegen/docs/examples.md) sections 7 and 8, and [architecture/consumer-contract.md](codegen/docs/architecture/consumer-contract.md) for the full surface.
+The codegen now publishes `@SingleIn`, `@Composable`, and `Modifier` in addition to the previously-published Metro and Decompose constants. See [annotations.md](https://github.com/thomaskioko/app-gradle-plugins/blob/main/codegen/docs/annotations.md), [examples.md](https://github.com/thomaskioko/app-gradle-plugins/blob/main/codegen/docs/examples.md) sections 7 and 8, and [architecture/consumer-contract.md](https://github.com/thomaskioko/app-gradle-plugins/blob/main/codegen/docs/architecture/consumer-contract.md) for the full surface.
 
 ### Lint rules
 
@@ -122,7 +122,7 @@ A new published `lint-rules` artifact ships six ktlint rules that enforce the pr
     - `tvmaniac:no-style-wrapper-in-preview` prevents redundant styling wrappers (`TvManiacTheme`, `TvManiacBackground`, `Surface`, `MaterialTheme` by default) inside `@Preview` composables. The wrapper provider applies the project styling once.
     - `tvmaniac:metro-redundant-inject` removes redundant `@Inject` from classes that already declare a Metro `@Contributes...` annotation. Autocorrect-able.
     - `tvmaniac:test-name-format` enforces the `should X given Y` test naming convention. Backticked and camelCase forms are both accepted.
-- The navigation and preview rules read `.editorconfig` properties (`ktlint_tvmaniac_navigation_module_paths`, `ktlint_tvmaniac_preview_wrappers`, `ktlint_tvmaniac_preview_wrapper_packages`) so consumer projects can adjust the navigation layer location and the set of forbidden wrappers without forking. See [lint-rules/README.md](lint-rules/README.md).
+- The navigation and preview rules read `.editorconfig` properties (`ktlint_tvmaniac_navigation_module_paths`, `ktlint_tvmaniac_preview_wrappers`, `ktlint_tvmaniac_preview_wrapper_packages`) so consumer projects can adjust the navigation layer location and the set of forbidden wrappers without forking. See [lint-rules/README.md](https://github.com/thomaskioko/app-gradle-plugins/blob/main/lint-rules/README.md).
 
 ### Misc
 

--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Builds the documentation site.
+#
+#   ./deploy_website.sh --local   serve on localhost and reload on every edit
+#   ./deploy_website.sh --ci      build into site/ and fail on any warning
+#
+# The served site lives under the same path as the published one, so open the
+# address MkDocs prints rather than the bare host.
+#
+# The site needs Python. Install what it needs with:
+#
+#   python3 -m pip install -r mkdocs-requirements.txt
+#
+# Publishing happens from a GitHub Actions workflow, not from here.
+
+set -euo pipefail
+
+MODE="${1:---local}"
+
+if [[ "${MODE}" != "--local" && "${MODE}" != "--ci" ]]; then
+  echo "usage: $0 [--local|--ci]" >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")"
+
+# The API reference is generated into docs/api and is not committed, so build it
+# first. Without this the nav points at folders that do not exist yet.
+./gradlew dokkaAll
+
+# GitHub wants these two at the repository root, and the site wants them as
+# pages. Copy rather than move, and keep the copies out of version control.
+cp CHANGELOG.md docs/changelog.md
+cp RELEASING.md docs/releasing.md
+
+if [[ "${MODE}" == "--local" ]]; then
+  mkdocs serve
+else
+  mkdocs build --strict --site-dir site
+fi

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,44 @@
+# App Gradle Plugins
+
+A module in a large project spends most of its build file repeating the same setup: the same
+target platforms, the same compiler flags, the same test dependencies. These plugins move that
+setup out of the build file and leave behind a `scaffold {}` block where a module declares only
+the choices it actually has to make.
+
+```kotlin
+plugins {
+  id("io.github.thomaskioko.gradle.plugins.multiplatform")
+}
+
+scaffold {
+  useMetro()
+}
+```
+
+## What is here
+
+**Convention plugins** for Kotlin Multiplatform, Android and JVM modules. Apply the root plugin on
+the root project and one platform plugin on each module, then describe the module through
+`scaffold {}`.
+
+**Code generation** for navigation and feature flags. Mark a presenter as a destination and the
+processor writes the dependency graph and the bindings that go with it, instead of leaving four
+mechanical files to be written by hand for every screen.
+
+**ktlint rules** for the conventions a type cannot enforce, such as keeping navigation
+construction inside the modules that own it, or requiring the code generation annotation rather
+than a binding written by hand.
+
+## Where to go next
+
+The [API reference](api/plugins/index.html) covers every plugin, every option in `scaffold {}`, and every
+annotation, generated from the source itself so it cannot drift away from the code.
+
+The [change log](changelog.md) records what changed in each release and what a consumer has to do
+about it, if anything.
+
+## Compatibility
+
+These plugins are built against AGP 9 and current Kotlin. They are published to Maven Central and
+used in production by [Tv Maniac](https://github.com/c0de-wizard/tv-maniac), which is where most
+of the requirements come from.

--- a/mkdocs-requirements.txt
+++ b/mkdocs-requirements.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-material==9.6.12
+pymdown-extensions==10.21.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,61 @@
+site_name: App Gradle Plugins
+site_description: Gradle plugins for building Kotlin Multiplatform and Android projects
+site_author: Thomas Kioko
+site_url: https://thomaskioko.github.io/app-gradle-plugins/
+
+repo_name: thomaskioko/app-gradle-plugins
+repo_url: https://github.com/thomaskioko/app-gradle-plugins
+edit_uri: edit/main/docs/
+
+copyright: Copyright &copy; 2026 Thomas Kioko
+
+theme:
+  name: material
+  features:
+    - content.action.edit
+    - content.code.copy
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+  palette:
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
+      primary: white
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
+      primary: black
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.magiclink
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+nav:
+  - Overview: index.md
+  - API reference:
+      - Plugins: api/plugins/index.html
+      - Codegen: api/codegen/index.html
+      - Lint rules: api/lint-rules/index.html
+  - Change log: changelog.md
+  - Releasing: releasing.md


### PR DESCRIPTION
## Description
This PR adds a documentation site. It carries the API reference, the change log and the release guide, and goes live when a release is tagged. Every pull request builds it and fails if a link or a menu entry points at a page that is not there, so it cannot quietly rot the way the README did.

## Changes
- Add the overview page, the menu, and the pinned versions of the tools that build the site
- Add a script that builds the site for publishing, or serves it locally while you edit
- Build the site on every pull request
- Publish the site when a release is tagged

## Bug Fixes
- Four links in the change log pointed at files by their path in the repository. They resolve on GitHub but not on the site, where the change log is a page of its own. They are full addresses now, which work in both places.
