### PR TITLE
Enable dependencyGuard for release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Change Log
 - Check how the plugins themselves are written, using the Android lint checks for Gradle code. They found real faults, listed above. The remaining findings are all one thing, using the root project from a module, which stops Gradle from configuring projects independently. Those are recorded so a new one still fails the build.
 - Add the Apache 2.0 license text at the repository root. Every artifact says it is licensed under Apache 2.0, but the license itself was never committed, so GitHub read the project as having no license.
 - Add the Apache license header to every Kotlin file, so the published sources carry it too. The formatter was switched on for `plugins` and `lint-rules` but never told which files to read, so most of the project had never been formatted or checked.
-- Only enable Dependency Guard on `:app` when release builds exist. `AppPlugin` always pinned Dependency Guard to `releaseRuntimeClasspath`, but `debugOnly` disables every non-debug variant, so that configuration never existed and any tool that force-realizes the task graph, including Android Studio's sync and a plain `./gradlew tasks`, failed with `Could not resolve the configurations named [releaseRuntimeClasspath]`. The guard now only registers when `debugOnly` is off, which already holds in CI and any full local build, so the release dependency baseline is still enforced where it matters.
+- Only enable Dependency Guard on `:app` when release builds exist, since `debugOnly` disables them and `releaseRuntimeClasspath` no longer resolves.
 
 ## 0.8.5 *(2026-07-24)*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Change Log
 - Check how the plugins themselves are written, using the Android lint checks for Gradle code. They found real faults, listed above. The remaining findings are all one thing, using the root project from a module, which stops Gradle from configuring projects independently. Those are recorded so a new one still fails the build.
 - Add the Apache 2.0 license text at the repository root. Every artifact says it is licensed under Apache 2.0, but the license itself was never committed, so GitHub read the project as having no license.
 - Add the Apache license header to every Kotlin file, so the published sources carry it too. The formatter was switched on for `plugins` and `lint-rules` but never told which files to read, so most of the project had never been formatted or checked.
+- Only enable Dependency Guard on `:app` when release builds exist. `AppPlugin` always pinned Dependency Guard to `releaseRuntimeClasspath`, but `debugOnly` disables every non-debug variant, so that configuration never existed and any tool that force-realizes the task graph, including Android Studio's sync and a plain `./gradlew tasks`, failed with `Could not resolve the configurations named [releaseRuntimeClasspath]`. The guard now only registers when `debugOnly` is off, which already holds in CI and any full local build, so the release dependency baseline is still enforced where it matters.
 
 ## 0.8.5 *(2026-07-24)*
 

--- a/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/AppPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/thomaskioko/gradle/plugins/AppPlugin.kt
@@ -67,7 +67,9 @@ public abstract class AppPlugin : Plugin<Project> {
 
         target.baseExtension.extensions.create("app", AppExtension::class.java)
 
-        target.setupDependencyGuard("releaseRuntimeClasspath")
+        if (!target.isDebugOnlyBuild()) {
+            target.setupDependencyGuard("releaseRuntimeClasspath")
+        }
 
         val properties = target.scaffoldProperties()
 


### PR DESCRIPTION
## Description
This PR enables Dependency Guard on `:app` only when release builds exist, since `debugOnly` disables them and `releaseRuntimeClasspath` no longer resolves.
